### PR TITLE
Overhaul web UI: remove half-baked features, add polish, states, and dark mode

### DIFF
--- a/scripts/dev_preview_server.py
+++ b/scripts/dev_preview_server.py
@@ -1,0 +1,151 @@
+"""Lightweight stdlib preview server for the web UI (development only).
+
+Drives the real filesystem-backed WebRepository (no ASGI server required) so the
+built SPA can be exercised against real case/run/doc data during UI work.
+
+    PYTHONPATH=src .runtime-env/python.exe scripts/dev_preview_server.py \
+        --data-root <repo-with-results> --dist web/ui/dist --port 18488
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from thorium_reactor.web.repository import WebRepository  # noqa: E402
+from thorium_reactor.web.schemas import model_to_dict  # noqa: E402
+
+DIST: Path
+REPO: WebRepository
+DATA_ROOT: Path
+
+
+def dump(obj):
+    if isinstance(obj, list):
+        return [model_to_dict(item) if hasattr(item, "model_dump") else item for item in obj]
+    return model_to_dict(obj) if hasattr(obj, "model_dump") else obj
+
+
+def fake_session():
+    return {
+        "email": "engineer@thorium.lab",
+        "is_admin": True,
+        "admin_emails": ["engineer@thorium.lab"],
+        "daily_run_limit": 5,
+        "runs_started_today": 1,
+        "runs_remaining_today": 4,
+        "rate_limit_date": "2026-07-07",
+        "resets_at": "2026-07-08T00:00:00Z",
+        "can_start_run": True,
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # quiet
+        pass
+
+    def _send_json(self, payload, status=200):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_file(self, path: Path, status=200):
+        data = path.read_bytes()
+        mime = mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+        self.send_response(status)
+        self.send_header("Content-Type", mime)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self):
+        path = urlparse(self.path).path
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            body = {}
+        parts = [p for p in path.split("/") if p]
+        try:
+            if len(parts) == 4 and parts[:2] == ["api", "cases"] and parts[3] == "validate-draft":
+                resp = REPO.validate_draft(parts[2], draft_yaml=body.get("draft_yaml"), patch=body.get("patch", {}))
+                return self._send_json(dump(resp))
+            if parts == ["api", "runs"]:
+                return self._send_json({"detail": "Run launching is disabled in preview mode."}, status=400)
+        except Exception as exc:  # noqa: BLE001
+            return self._send_json({"detail": str(exc)}, status=400)
+        self._send_json({"detail": "Not found"}, status=404)
+
+    def do_GET(self):
+        path = unquote(urlparse(self.path).path)
+        parts = [p for p in path.split("/") if p]
+        try:
+            if path == "/api/health":
+                return self._send_json({"status": "ok", "repo_root": str(DATA_ROOT)})
+            if path == "/api/me":
+                return self._send_json(fake_session())
+            if path == "/api/cases":
+                return self._send_json(dump(REPO.list_cases()))
+            if len(parts) == 3 and parts[:2] == ["api", "cases"]:
+                return self._send_json(dump(REPO.get_case(parts[2])))
+            if path == "/api/runs":
+                return self._send_json(dump(REPO.list_runs()))
+            if len(parts) == 4 and parts[:2] == ["api", "runs"]:
+                return self._send_json(dump(REPO.get_run(parts[2], parts[3])))
+            if len(parts) >= 6 and parts[:2] == ["api", "runs"] and parts[4] == "artifacts":
+                artifact_path = "/".join(parts[5:])
+                resolved = REPO.resolve_artifact_path(parts[2], parts[3], artifact_path)
+                return self._send_file(resolved)
+            if len(parts) == 5 and parts[:2] == ["api", "runs"] and parts[4] == "events":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.end_headers()
+                return
+            if path == "/api/docs":
+                return self._send_json(dump(REPO.list_docs()))
+            if len(parts) == 3 and parts[:2] == ["api", "docs"]:
+                return self._send_json(dump(REPO.get_doc(parts[2])))
+            if path == "/api/admin/rate-limits":
+                return self._send_json([])
+        except FileNotFoundError as exc:
+            return self._send_json({"detail": str(exc)}, status=404)
+        except Exception as exc:  # noqa: BLE001
+            return self._send_json({"detail": str(exc)}, status=400)
+
+        candidate = (DIST / path.lstrip("/")).resolve()
+        if candidate.is_file() and str(candidate).startswith(str(DIST.resolve())):
+            return self._send_file(candidate)
+        index = DIST / "index.html"
+        if index.is_file():
+            return self._send_file(index)
+        self._send_json({"detail": "dist not built"}, status=404)
+
+
+def main():
+    global DIST, REPO, DATA_ROOT
+    here = Path(__file__).resolve().parents[1]
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-root", default=str(here), help="repo root that contains configs/, results/, docs/")
+    ap.add_argument("--dist", default=str(here / "web" / "ui" / "dist"))
+    ap.add_argument("--port", type=int, default=18488)
+    args = ap.parse_args()
+    DATA_ROOT = Path(args.data_root).resolve()
+    DIST = Path(args.dist).resolve()
+    REPO = WebRepository(DATA_ROOT)
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"Preview server on http://127.0.0.1:{args.port} (data_root={DATA_ROOT}, dist={DIST})")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,9 +1,26 @@
 import { Suspense, lazy, useEffect, useState } from "react";
 import { NavLink, Route, Routes, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Activity, Atom, Box, BookOpen, Boxes, FlaskConical, Gauge, Menu, PlaySquare, ShieldCheck, X } from "lucide-react";
+import {
+  Activity,
+  Atom,
+  Box,
+  BookOpen,
+  Boxes,
+  Gauge,
+  Menu,
+  Monitor,
+  Moon,
+  PlaySquare,
+  ShieldCheck,
+  Sun,
+  UserCircle2,
+  X
+} from "lucide-react";
 import { api } from "./api";
-import { ExpandableText } from "./components/ExpandableText";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { Truncate } from "./components/Truncate";
+import { useTheme, type ThemeMode } from "./theme";
 
 const Dashboard = lazy(() => import("./pages/Dashboard").then((module) => ({ default: module.Dashboard })));
 const Cases = lazy(() => import("./pages/Cases").then((module) => ({ default: module.Cases })));
@@ -17,9 +34,9 @@ const navigation = [
   { to: "/", label: "Dashboard", icon: Gauge },
   { to: "/cases", label: "Simulations", icon: Atom },
   { to: "/builder", label: "Builder", icon: PlaySquare },
-  { to: "/runs", label: "Run log", icon: Activity },
+  { to: "/runs", label: "Runs", icon: Activity },
   { to: "/docs", label: "Science", icon: BookOpen },
-  { to: "/viewer", label: "3D", icon: Box }
+  { to: "/viewer", label: "3D viewer", icon: Box }
 ];
 
 export function App() {
@@ -39,7 +56,7 @@ export function App() {
           <Boxes aria-hidden="true" />
           <div>
             <strong>Thorium Lab</strong>
-            <span>MSR simulation</span>
+            <span>MSR simulation console</span>
           </div>
           <button
             type="button"
@@ -69,27 +86,83 @@ export function App() {
             );
           })}
         </nav>
-        <div className="sidebar-note">
-          <FlaskConical aria-hidden="true" />
-          <ExpandableText lines={2}>{session.data?.email ?? "Draft runs write isolated bundle snapshots."}</ExpandableText>
+        <div className="account-block">
+          <ThemeToggle />
+          <AccountCard
+            status={session.status}
+            email={session.data?.email}
+            isAdmin={session.data?.is_admin ?? false}
+          />
         </div>
       </aside>
       <main className="main-panel">
-        <Suspense fallback={<div className="route-loading">Loading...</div>}>
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/cases" element={<Cases />} />
-            <Route path="/builder" element={<Builder />} />
-            <Route path="/runs" element={<Runs />} />
-            <Route path="/runs/:caseName/:runId" element={<Runs />} />
-            <Route path="/docs" element={<Docs />} />
-            <Route path="/docs/:slug" element={<Docs />} />
-            <Route path="/viewer" element={<Viewer />} />
-            <Route path="/viewer/:caseName/:runId" element={<Viewer />} />
-            <Route path="/admin" element={<Admin />} />
-          </Routes>
-        </Suspense>
+        <ErrorBoundary resetKey={location.pathname}>
+          <Suspense fallback={<div className="route-loading">Loading…</div>}>
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/cases" element={<Cases />} />
+              <Route path="/cases/:caseName" element={<Cases />} />
+              <Route path="/builder" element={<Builder />} />
+              <Route path="/runs" element={<Runs />} />
+              <Route path="/runs/:caseName/:runId" element={<Runs />} />
+              <Route path="/docs" element={<Docs />} />
+              <Route path="/docs/:slug" element={<Docs />} />
+              <Route path="/viewer" element={<Viewer />} />
+              <Route path="/viewer/:caseName/:runId" element={<Viewer />} />
+              <Route path="/admin" element={<Admin />} />
+            </Routes>
+          </Suspense>
+        </ErrorBoundary>
       </main>
+    </div>
+  );
+}
+
+function AccountCard({ status, email, isAdmin }: { status: "pending" | "error" | "success"; email?: string; isAdmin: boolean }) {
+  const value = status === "pending" ? "Signing in…" : status === "error" ? "Session unavailable" : email ?? "Local session";
+  return (
+    <div className="account-card">
+      <UserCircle2 aria-hidden="true" />
+      <span className="account-label">Signed in</span>
+      <Truncate className="account-value" title={value}>
+        {value}
+      </Truncate>
+      {isAdmin && (
+        <span className="account-badge">
+          <ShieldCheck aria-hidden="true" width={12} height={12} />
+          Admin
+        </span>
+      )}
+    </div>
+  );
+}
+
+const themeOptions: Array<{ value: ThemeMode; icon: typeof Sun; label: string }> = [
+  { value: "light", icon: Sun, label: "Light theme" },
+  { value: "system", icon: Monitor, label: "System theme" },
+  { value: "dark", icon: Moon, label: "Dark theme" }
+];
+
+function ThemeToggle() {
+  const { mode, setMode } = useTheme();
+  return (
+    <div className="theme-toggle" role="group" aria-label="Color theme">
+      {themeOptions.map((option) => {
+        const Icon = option.icon;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={mode === option.value ? "active" : ""}
+            aria-label={option.label}
+            aria-pressed={mode === option.value}
+            title={option.label}
+            onClick={() => setMode(option.value)}
+          >
+            <Icon aria-hidden="true" />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/ui/src/api.ts
+++ b/web/ui/src/api.ts
@@ -1,4 +1,14 @@
-import type { AuthSession, CaseDetail, CaseSummary, DocRecord, DocSummary, RateLimitRecord, RunRecord, SimulationDraft } from "./types";
+import type {
+  AuthSession,
+  CaseDetail,
+  CaseSummary,
+  DocRecord,
+  DocSummary,
+  DraftValidationResponse,
+  RateLimitRecord,
+  RunRecord,
+  SimulationDraft
+} from "./types";
 
 async function request<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -26,6 +36,11 @@ export const api = {
   run: (caseName: string, runId: string) => request<RunRecord>(`/api/runs/${caseName}/${runId}`),
   createRun: (draft: SimulationDraft) =>
     request<RunRecord>("/api/runs", { method: "POST", body: JSON.stringify(draft) }),
+  validateDraft: (caseName: string, patch: Record<string, unknown>) =>
+    request<DraftValidationResponse>(`/api/cases/${caseName}/validate-draft`, {
+      method: "POST",
+      body: JSON.stringify({ patch })
+    }),
   rateLimits: () => request<RateLimitRecord[]>("/api/admin/rate-limits"),
   resetRateLimit: (email: string) =>
     request<RateLimitRecord>(`/api/admin/rate-limits/${encodeURIComponent(email)}/reset`, { method: "POST" }),

--- a/web/ui/src/components/ErrorBoundary.tsx
+++ b/web/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { AlertOctagon, RotateCcw } from "lucide-react";
+
+interface Props {
+  children: ReactNode;
+  /** Optional custom fallback; receives the error and a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  title?: string;
+  /** When this value changes, a caught error is cleared (e.g. on route change). */
+  resetKey?: unknown;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/** Catches render-time throws so a single failing subtree never blanks the app. */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: Props): void {
+    // Recover automatically when the caller signals a context change (e.g. the
+    // user navigated to a different route), so the fallback isn't pinned forever.
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surface for local debugging without crashing the shell.
+    console.error("UI error boundary caught:", error, info.componentStack);
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback(error, this.reset);
+    return (
+      <div className="state-block error tall" role="alert">
+        <AlertOctagon aria-hidden="true" />
+        <div>
+          <strong>{this.props.title ?? "Something went wrong rendering this view."}</strong>
+          <span className="state-detail">{error.message}</span>
+        </div>
+        <button type="button" className="secondary-action" onClick={this.reset}>
+          <RotateCcw aria-hidden="true" />
+          <span>Try again</span>
+        </button>
+      </div>
+    );
+  }
+}

--- a/web/ui/src/components/ExpandableText.tsx
+++ b/web/ui/src/components/ExpandableText.tsx
@@ -1,4 +1,14 @@
-import { type CSSProperties, type KeyboardEvent, type MouseEvent, type ReactNode, useState } from "react";
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState
+} from "react";
 
 interface ExpandableTextProps {
   children: ReactNode;
@@ -8,17 +18,50 @@ interface ExpandableTextProps {
   title?: string;
 }
 
+/**
+ * Click-to-expand for genuinely long free text (summaries, notes, messages).
+ * The expand affordance (button role, tab stop, aria-expanded) is exposed only
+ * when the content actually overflows its clamp, so short bounded values don't
+ * emit spurious keyboard/screen-reader stops.
+ */
 export function ExpandableText({ children, className, insideInteractive = false, lines = 1, title }: ExpandableTextProps) {
   const [expanded, setExpanded] = useState(false);
+  const [clamped, setClamped] = useState(false);
+  const innerRef = useRef<HTMLSpanElement>(null);
   const textTitle = title ?? (typeof children === "string" || typeof children === "number" ? String(children) : undefined);
   const style = { "--line-count": String(lines) } as CSSProperties;
   const clampStyle = { WebkitLineClamp: expanded ? undefined : lines } as CSSProperties;
 
+  const measure = useCallback(() => {
+    const node = innerRef.current;
+    if (!node) return;
+    setClamped(node.scrollHeight - 1 > node.clientHeight || node.scrollWidth - 1 > node.clientWidth);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (expanded) return;
+    measure();
+  }, [children, lines, expanded, measure]);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const node = innerRef.current;
+    if (!node) return;
+    const observer = new ResizeObserver(() => {
+      if (!expanded) measure();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [expanded, measure]);
+
+  // Interactive only when the parent isn't already interactive and the text is
+  // (or was) actually clamped.
+  const interactive = !insideInteractive && (clamped || expanded);
+
   function toggle(event: MouseEvent<HTMLSpanElement>) {
-    if (!insideInteractive) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
+    if (!interactive) return;
+    event.preventDefault();
+    event.stopPropagation();
     setExpanded((current) => !current);
   }
 
@@ -30,16 +73,18 @@ export function ExpandableText({ children, className, insideInteractive = false,
 
   return (
     <span
-      aria-expanded={insideInteractive ? undefined : expanded}
-      className={["expandable-text", expanded ? "expanded" : "", className].filter(Boolean).join(" ")}
-      onClick={toggle}
-      onKeyDown={insideInteractive ? undefined : handleKeyDown}
-      role={insideInteractive ? undefined : "button"}
+      aria-expanded={interactive ? expanded : undefined}
+      className={["expandable-text", interactive ? "interactive" : "", expanded ? "expanded" : "", className].filter(Boolean).join(" ")}
+      onClick={interactive ? toggle : undefined}
+      onKeyDown={interactive ? handleKeyDown : undefined}
+      role={interactive ? "button" : undefined}
       style={style}
-      tabIndex={insideInteractive ? undefined : 0}
+      tabIndex={interactive ? 0 : undefined}
       title={textTitle}
     >
-      <span style={clampStyle}>{children}</span>
+      <span ref={innerRef} style={clampStyle}>
+        {children}
+      </span>
     </span>
   );
 }

--- a/web/ui/src/components/Markdown.tsx
+++ b/web/ui/src/components/Markdown.tsx
@@ -1,3 +1,5 @@
+import type { ComponentType, ReactNode } from "react";
+import { isValidElement } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
@@ -5,11 +7,61 @@ import remarkMath from "remark-math";
 interface MarkdownProps {
   className?: string;
   content: string;
+  /** Add id anchors to headings so an outline can link to them. */
+  anchors?: boolean;
 }
 
-export function Markdown({ className = "markdown-body", content }: MarkdownProps) {
+/** GitHub-style slug for a single heading (before de-duplication). */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+/**
+ * A stateful slugger that disambiguates repeated headings the way GitHub does
+ * (`results`, `results-1`, …). The Docs outline and the rendered headings each
+ * instantiate one over the same ordered heading list, so their ids stay in sync.
+ */
+export function makeSlugger(): (text: string) => string {
+  const seen = new Map<string, number>();
+  return (text: string) => {
+    const base = slugify(text);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count}`;
+  };
+}
+
+function textOf(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) return textOf((node.props as { children?: ReactNode }).children);
+  return "";
+}
+
+const HEADING_TAGS = ["h1", "h2", "h3", "h4", "h5", "h6"] as const;
+
+/** Fresh heading renderers per call so the slugger counter resets each render. */
+function buildHeadingComponents() {
+  const slug = makeSlugger();
+  const components: Record<string, ComponentType<{ children?: ReactNode }>> = {};
+  for (const tag of HEADING_TAGS) {
+    const Tag = tag;
+    components[tag] = ({ children }) => <Tag id={slug(textOf(children))}>{children}</Tag>;
+  }
+  return components;
+}
+
+export function Markdown({ className = "markdown-body", content, anchors = false }: MarkdownProps) {
+  // Rebuilt each render (cheap) so heading de-duplication is deterministic and
+  // never accumulates counts across renders.
+  const components = anchors ? buildHeadingComponents() : undefined;
   return (
-    <ReactMarkdown className={className} remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex]}>
+    <ReactMarkdown className={className} remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex]} components={components}>
       {content}
     </ReactMarkdown>
   );

--- a/web/ui/src/components/MetricChart.tsx
+++ b/web/ui/src/components/MetricChart.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import ReactECharts from "echarts-for-react";
+import { prefersReducedMotion, useChartTokens } from "../theme";
 import type { NumericRow } from "../runData";
 
 interface MetricChartProps {
@@ -12,6 +13,7 @@ interface MetricChartProps {
 
 export function MetricChart({ className, limit = 18, metrics, rows: explicitRows, title = "Metrics" }: MetricChartProps) {
   const compact = useCompactChart();
+  const tokens = useChartTokens();
   const fallbackRows: NumericRow[] = Object.entries(metrics ?? {})
     .filter(([, value]) => typeof value === "number" && Number.isFinite(value))
     .map(([label, value]) => ({ label, value: value as number }));
@@ -24,13 +26,20 @@ export function MetricChart({ className, limit = 18, metrics, rows: explicitRows
 
   const height = Math.max(240, Math.min(520, 72 + chartRows.length * (compact ? 24 : 28)));
   const option = {
-    title: { text: title, left: 0, textStyle: { fontSize: 13, fontWeight: 600 } },
+    animation: !prefersReducedMotion(),
+    title: { text: title, left: 0, textStyle: { fontSize: 13, fontWeight: 600, color: tokens.label } },
     grid: { left: compact ? 88 : 132, right: compact ? 8 : 18, top: 42, bottom: 24 },
-    xAxis: { type: "value", axisLabel: { color: "#51606f" }, splitLine: { lineStyle: { color: "#dfe5ea" } } },
+    xAxis: {
+      type: "value",
+      axisLabel: { color: tokens.axis },
+      axisLine: { lineStyle: { color: tokens.grid } },
+      splitLine: { lineStyle: { color: tokens.grid } }
+    },
     yAxis: {
       type: "category",
       data: chartRows.map((row) => row.label),
-      axisLabel: { color: "#303944", width: compact ? 78 : 122, overflow: "truncate" }
+      axisLine: { lineStyle: { color: tokens.grid } },
+      axisLabel: { color: tokens.label, width: compact ? 78 : 122, overflow: "truncate" }
     },
     tooltip: {
       trigger: "axis",
@@ -46,7 +55,7 @@ export function MetricChart({ className, limit = 18, metrics, rows: explicitRows
           unit: row.unit,
           value: row.value
         })),
-        itemStyle: { color: "#0f766e", borderRadius: [0, 3, 3, 0] }
+        itemStyle: { color: tokens.accent, borderRadius: [0, 3, 3, 0] }
       }
     ]
   };

--- a/web/ui/src/components/ModelViewer.tsx
+++ b/web/ui/src/components/ModelViewer.tsx
@@ -5,6 +5,7 @@ import { Layers, Maximize2, ZoomIn, ZoomOut } from "lucide-react";
 import { Vector3 } from "three";
 import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import { viewableGeometryArtifact } from "../geometryArtifacts";
+import { prefersReducedMotion, useTheme } from "../theme";
 import type { ArtifactRef } from "../types";
 
 interface ModelViewerProps {
@@ -13,8 +14,10 @@ interface ModelViewerProps {
 
 export function ModelViewer({ artifacts }: ModelViewerProps) {
   const gltf = viewableGeometryArtifact(artifacts);
+  const { scheme } = useTheme();
   const [showGrid, setShowGrid] = useState(true);
   const [zoomCommand, setZoomCommand] = useState(0);
+  const dark = scheme === "dark";
 
   if (!gltf) {
     return <div className="empty-panel tall">This run has no viewable glTF geometry export.</div>;
@@ -37,11 +40,11 @@ export function ModelViewer({ artifacts }: ModelViewerProps) {
         </a>
       </div>
       <Canvas camera={{ position: [4, 3, 5], fov: 42 }} dpr={[1, 1.75]} gl={{ antialias: true, preserveDrawingBuffer: true }}>
-        <color attach="background" args={["#f6f8fa"]} />
-        <ambientLight intensity={0.7} />
+        <color attach="background" args={[dark ? "#111b1e" : "#f6f8fa"]} />
+        <ambientLight intensity={dark ? 0.9 : 0.7} />
         <directionalLight position={[5, 8, 5]} intensity={1.6} />
-        {showGrid && <gridHelper args={[8, 16, "#7c8a97", "#d2dbe3"]} position={[0, -1.2, 0]} />}
-        <Suspense fallback={<Html center>Loading geometry...</Html>}>
+        {showGrid && <gridHelper args={[8, 16, dark ? "#3a4a4d" : "#7c8a97", dark ? "#243033" : "#d2dbe3"]} position={[0, -1.2, 0]} />}
+        <Suspense fallback={<Html center>Loading geometry…</Html>}>
           <Bounds fit clip observe margin={1.2}>
             <ReactorScene url={gltf.url} />
           </Bounds>
@@ -72,7 +75,7 @@ function ViewerOrbitControls({ zoomCommand }: { zoomCommand: number }) {
     lastZoomCommand.current = zoomCommand;
   }, [camera, zoomCommand]);
 
-  return <OrbitControls ref={controls} makeDefault enableDamping dampingFactor={0.08} />;
+  return <OrbitControls ref={controls} makeDefault enableDamping={!prefersReducedMotion()} dampingFactor={0.08} />;
 }
 
 function ReactorScene({ url }: { url: string }) {

--- a/web/ui/src/components/ProgressBar.tsx
+++ b/web/ui/src/components/ProgressBar.tsx
@@ -1,0 +1,24 @@
+interface ProgressBarProps {
+  /** Progress fraction in [0, 1]. When omitted, renders an indeterminate bar. */
+  value?: number | null;
+  label?: string;
+}
+
+/** Determinate/indeterminate progress bar driven by real run progress. */
+export function ProgressBar({ value, label }: ProgressBarProps) {
+  const indeterminate = value === null || value === undefined || !Number.isFinite(value);
+  const clamped = indeterminate ? 0 : Math.max(0, Math.min(1, value));
+  const percent = Math.round(clamped * 100);
+  return (
+    <div
+      className={`progress-bar${indeterminate ? " indeterminate" : ""}`}
+      role="progressbar"
+      aria-label={label ?? "Run progress"}
+      aria-valuenow={indeterminate ? undefined : percent}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <span className="progress-fill" style={indeterminate ? undefined : { width: `${percent}%` }} />
+    </div>
+  );
+}

--- a/web/ui/src/components/RunArtifacts.tsx
+++ b/web/ui/src/components/RunArtifacts.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Database, ExternalLink, FileJson, Image, ScrollText } from "lucide-react";
 import { fetchText } from "../api";
-import { ExpandableText } from "./ExpandableText";
+import { Truncate } from "./Truncate";
 import { Markdown } from "./Markdown";
 import type { ArtifactRef } from "../types";
 import { formatSize, visualArtifacts } from "../runData";
@@ -29,7 +29,11 @@ export function RunArtifacts({ artifacts }: RunArtifactsProps) {
           <span>Report</span>
         </div>
         {report ? (
-          <Markdown content={reportQuery.data ?? "Loading report..."} />
+          reportQuery.isError ? (
+            <div className="empty-panel">Could not load report: {(reportQuery.error as Error)?.message ?? "unknown error"}</div>
+          ) : (
+            <Markdown content={reportQuery.data ?? "Loading report…"} />
+          )
         ) : (
           <div className="empty-panel">No report artifact yet.</div>
         )}
@@ -58,9 +62,7 @@ export function RunArtifacts({ artifacts }: RunArtifactsProps) {
           {files.map((artifact) => (
             <div className="file-item" key={artifact.path}>
               <FileJson aria-hidden="true" />
-              <ExpandableText className="file-name" lines={1}>
-                {artifact.label}
-              </ExpandableText>
+              <Truncate className="file-name">{artifact.label}</Truncate>
               <small>
                 {artifact.kind} / {formatSize(artifact.size)}
               </small>

--- a/web/ui/src/components/RunDataExplorer.tsx
+++ b/web/ui/src/components/RunDataExplorer.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import ReactECharts from "echarts-for-react";
 import { BarChart3, ClipboardList, Database, FileJson, Gauge, Sigma, SlidersHorizontal, Table2, type LucideIcon } from "lucide-react";
 import { fetchText } from "../api";
+import { prefersReducedMotion, useChartTokens } from "../theme";
 import {
   artifactKindRows,
   displayValue,
@@ -16,6 +17,7 @@ import {
 import type { FlatDataRow, NumericRow, ParsedArtifact } from "../runData";
 import type { ArtifactRef, RunRecord } from "../types";
 import { MetricChart } from "./MetricChart";
+import { PanelError } from "./StateBlock";
 
 interface RunDataExplorerProps {
   run: RunRecord;
@@ -103,7 +105,14 @@ export function RunDataExplorer({ run }: RunDataExplorerProps) {
                 </button>
               ))}
             </div>
-            <ArtifactPreview artifact={selectedArtifact} isLoading={artifactText.isLoading} parsed={parsedArtifact} />
+            <ArtifactPreview
+              artifact={selectedArtifact}
+              isLoading={artifactText.isLoading}
+              isError={artifactText.isError}
+              error={artifactText.error}
+              onRetry={() => artifactText.refetch()}
+              parsed={parsedArtifact}
+            />
           </div>
         ) : (
           <div className="empty-panel">No structured artifacts were found for this run.</div>
@@ -124,15 +133,18 @@ function RunKpi({ icon: Icon, label, value }: { icon: LucideIcon; label: string;
 }
 
 function ArtifactDonut({ rows }: { rows: NumericRow[] }) {
+  const tokens = useChartTokens();
   if (!rows.length) return <div className="empty-panel">No artifacts counted.</div>;
   const option = {
-    color: ["#006d63", "#285f87", "#8a5a00", "#5a6c76", "#a33a2a", "#5b7d5b"],
-    legend: { bottom: 0, type: "scroll" },
+    animation: !prefersReducedMotion(),
+    color: tokens.series,
+    legend: { bottom: 0, type: "scroll", textStyle: { color: tokens.label } },
     series: [
       {
         avoidLabelOverlap: true,
         data: rows.map((row) => ({ name: row.label, value: row.value })),
-        label: { formatter: "{b}: {c}" },
+        label: { formatter: "{b}: {c}", color: tokens.label },
+        labelLine: { lineStyle: { color: tokens.axis } },
         radius: ["46%", "70%"],
         type: "pie"
       }
@@ -145,14 +157,23 @@ function ArtifactDonut({ rows }: { rows: NumericRow[] }) {
 function ArtifactPreview({
   artifact,
   isLoading,
+  isError,
+  error,
+  onRetry,
   parsed
 }: {
   artifact?: ArtifactRef;
   isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  onRetry: () => void;
   parsed: ParsedArtifact | null;
 }) {
   if (!artifact) return <div className="empty-panel">Select an artifact to preview.</div>;
-  if (isLoading || !parsed) return <div className="empty-panel">Loading {artifact.label}...</div>;
+  if (isError) {
+    return <PanelError error={error} label={`Could not load ${artifact.label}.`} onRetry={onRetry} />;
+  }
+  if (isLoading || !parsed) return <div className="empty-panel">Loading {artifact.label}…</div>;
   if (parsed.kind === "error") {
     return <div className="empty-panel">Could not parse {artifact.label}: {parsed.error}</div>;
   }

--- a/web/ui/src/components/RunOutputSections.tsx
+++ b/web/ui/src/components/RunOutputSections.tsx
@@ -1,5 +1,7 @@
 import { Activity, AlertCircle, Atom, BadgeCheck, BarChart3, Box, Factory, FlaskConical, Gauge, Landmark, Waves } from "lucide-react";
 import { ExpandableText } from "./ExpandableText";
+import { Truncate } from "./Truncate";
+import { StatusBadge } from "./StatusBadge";
 import type { OutputMetric, OutputSection } from "../types";
 
 interface RunOutputSectionsProps {
@@ -34,13 +36,7 @@ export function RunOutputSections({ sections }: RunOutputSectionsProps) {
                 <Icon aria-hidden="true" />
                 <h2>{section.title}</h2>
               </div>
-              {section.status && (
-                <mark>
-                  <ExpandableText insideInteractive lines={1}>
-                    {section.status.replaceAll("_", " ")}
-                  </ExpandableText>
-                </mark>
-              )}
+              {section.status && <StatusBadge status={section.status} dot={false} />}
             </div>
 
             {section.summary && (
@@ -78,12 +74,10 @@ function MetricCell({ metric }: { metric: OutputMetric }) {
   return (
     <div className="output-metric">
       <dt>
-        <ExpandableText lines={1}>{metric.label}</ExpandableText>
+        <Truncate lines={2}>{metric.label}</Truncate>
       </dt>
       <dd>
-        <ExpandableText className="output-metric-value" lines={1}>
-          {formatMetricValue(metric)}
-        </ExpandableText>
+        <Truncate className="output-metric-value">{formatMetricValue(metric)}</Truncate>
       </dd>
     </div>
   );

--- a/web/ui/src/components/StateBlock.tsx
+++ b/web/ui/src/components/StateBlock.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, Inbox, RotateCcw } from "lucide-react";
+
+interface LoadingProps {
+  label?: string;
+  lines?: number;
+  tall?: boolean;
+}
+
+/** Skeleton placeholder shown while a panel's data is loading. */
+export function PanelLoading({ label = "Loading", lines = 3, tall = false }: LoadingProps) {
+  return (
+    <div className={`state-block loading${tall ? " tall" : ""}`} role="status" aria-live="polite">
+      <span className="visually-hidden">{label}…</span>
+      <div className="skeleton-lines" aria-hidden="true">
+        {Array.from({ length: lines }).map((_, index) => (
+          <span key={index} className="skeleton-line" style={{ width: `${90 - index * 14}%` }} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ErrorProps {
+  error?: unknown;
+  label?: string;
+  onRetry?: () => void;
+  tall?: boolean;
+}
+
+/** Honest error surface with an optional retry action. */
+export function PanelError({ error, label = "Could not load this data.", onRetry, tall = false }: ErrorProps) {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
+  return (
+    <div className={`state-block error${tall ? " tall" : ""}`} role="alert">
+      <AlertTriangle aria-hidden="true" />
+      <div>
+        <strong>{label}</strong>
+        {message && <span className="state-detail">{message}</span>}
+      </div>
+      {onRetry && (
+        <button type="button" className="secondary-action" onClick={onRetry}>
+          <RotateCcw aria-hidden="true" />
+          <span>Retry</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface EmptyProps {
+  children: ReactNode;
+  icon?: typeof Inbox;
+  tall?: boolean;
+}
+
+/** Neutral empty state — distinct from loading and error. */
+export function EmptyState({ children, icon: Icon = Inbox, tall = false }: EmptyProps) {
+  return (
+    <div className={`state-block empty${tall ? " tall" : ""}`}>
+      <Icon aria-hidden="true" />
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/web/ui/src/components/StatusBadge.tsx
+++ b/web/ui/src/components/StatusBadge.tsx
@@ -1,0 +1,33 @@
+type Tone = "ok" | "warn" | "danger" | "info" | "neutral";
+
+const TONE_BY_KEYWORD: Array<[RegExp, Tone]> = [
+  [/(complete|completed|pass|passed|ready|ok|valid|success|ended)/i, "ok"],
+  [/(running|queued|active|in[_-]?progress|started|live)/i, "info"],
+  [/(fail|failed|error|blocked|missing|canceled|cancelled|reversal|high[_-]?risk)/i, "danger"],
+  [/(pending|warn|warning|built|partial|medium|degraded|caution)/i, "warn"]
+];
+
+function toneFor(status: string): Tone {
+  for (const [pattern, tone] of TONE_BY_KEYWORD) {
+    if (pattern.test(status)) return tone;
+  }
+  return "neutral";
+}
+
+interface StatusBadgeProps {
+  status: string;
+  /** Show a leading dot indicator (default true). */
+  dot?: boolean;
+  className?: string;
+}
+
+/** Color-coded status pill used for run and output-section statuses. */
+export function StatusBadge({ status, dot = true, className }: StatusBadgeProps) {
+  const label = status.replaceAll("_", " ");
+  return (
+    <span className={["status-badge", `tone-${toneFor(status)}`, className].filter(Boolean).join(" ")} title={label}>
+      {dot && <span className="status-dot" aria-hidden="true" />}
+      <span className="status-label">{label}</span>
+    </span>
+  );
+}

--- a/web/ui/src/components/Truncate.tsx
+++ b/web/ui/src/components/Truncate.tsx
@@ -1,0 +1,27 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface TruncateProps {
+  children: ReactNode;
+  className?: string;
+  /** Number of lines before clamping (default 1). */
+  lines?: number;
+  /** Native tooltip text; defaults to the string content. */
+  title?: string;
+  as?: "span" | "div";
+}
+
+/**
+ * Bounded-value truncation: pure CSS line-clamp plus a native title tooltip.
+ * Use for labels, values, counts, and metadata — anything short and known.
+ * For long free text that benefits from click-to-expand, use ExpandableText.
+ */
+export function Truncate({ children, className, lines = 1, title, as = "span" }: TruncateProps) {
+  const style = { "--clamp-lines": String(lines) } as CSSProperties;
+  const tooltip = title ?? (typeof children === "string" || typeof children === "number" ? String(children) : undefined);
+  const Tag = as;
+  return (
+    <Tag className={["truncate", className].filter(Boolean).join(" ")} style={style} title={tooltip}>
+      {children}
+    </Tag>
+  );
+}

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -3,8 +3,12 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
+import { applyTheme, getStoredTheme } from "./theme";
 import "katex/dist/katex.min.css";
 import "./styles.css";
+
+// Apply the persisted theme before first paint.
+applyTheme(getStoredTheme());
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/web/ui/src/pages/Admin.tsx
+++ b/web/ui/src/pages/Admin.tsx
@@ -1,15 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { RotateCcw, ShieldCheck } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
+import { Truncate } from "../components/Truncate";
+import { PanelError, PanelLoading, EmptyState } from "../components/StateBlock";
 
 export function Admin() {
   const queryClient = useQueryClient();
   const session = useQuery({ queryKey: ["me"], queryFn: api.me, retry: false });
+  const isAdmin = session.data?.is_admin === true;
   const limits = useQuery({
     queryKey: ["rate-limits"],
     queryFn: api.rateLimits,
-    enabled: session.data?.is_admin === true
+    enabled: isAdmin
   });
   const reset = useMutation({
     mutationFn: api.resetRateLimit,
@@ -19,28 +21,27 @@ export function Admin() {
     }
   });
 
-  if (session.data && !session.data.is_admin) {
+  if (session.isLoading) {
     return (
       <div className="page">
-        <header className="page-header">
-          <div>
-            <p className="eyebrow">Access control</p>
-            <h1>Admin console</h1>
-          </div>
-        </header>
-        <div className="empty-panel tall">Admin access required.</div>
+        <AdminHeader />
+        <PanelLoading label="Checking access" lines={3} tall />
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="page">
+        <AdminHeader />
+        <EmptyState tall icon={ShieldCheck}>Admin access required.</EmptyState>
       </div>
     );
   }
 
   return (
     <div className="page">
-      <header className="page-header">
-        <div>
-          <p className="eyebrow">Access control</p>
-          <h1>Admin console</h1>
-        </div>
-      </header>
+      <AdminHeader />
 
       <section className="dashboard-grid">
         <div className="panel">
@@ -51,7 +52,7 @@ export function Admin() {
           <div className="tag-row">
             {session.data?.admin_emails.map((email) => (
               <span key={email}>
-                <ExpandableText lines={1}>{email}</ExpandableText>
+                <Truncate>{email}</Truncate>
               </span>
             ))}
           </div>
@@ -64,7 +65,9 @@ export function Admin() {
           <dl className="fact-list">
             <div>
               <dt>Current user</dt>
-              <dd>{session.data?.email ?? "Loading"}</dd>
+              <dd>
+                <Truncate>{session.data?.email ?? "Loading"}</Truncate>
+              </dd>
             </div>
             <div>
               <dt>Limit</dt>
@@ -79,7 +82,11 @@ export function Admin() {
           <RotateCcw aria-hidden="true" />
           <h2>Rate limits</h2>
         </div>
-        {limits.data?.length ? (
+        {limits.isLoading ? (
+          <PanelLoading label="Loading rate limits" lines={4} />
+        ) : limits.isError ? (
+          <PanelError error={limits.error} onRetry={() => limits.refetch()} />
+        ) : limits.data?.length ? (
           <div className="admin-table">
             <div className="admin-row header">
               <span>User</span>
@@ -92,29 +99,20 @@ export function Admin() {
             {limits.data.map((record) => (
               <div className="admin-row" key={record.email}>
                 <strong data-label="User">
-                  <ExpandableText lines={1}>{record.email}</ExpandableText>
+                  <Truncate>{record.email}</Truncate>
                 </strong>
                 <span data-label="Date">
-                  <ExpandableText lines={1}>{record.date}</ExpandableText>
+                  <Truncate>{record.date}</Truncate>
                 </span>
                 <span data-label="Starts">
-                  <ExpandableText lines={1}>
-                    {record.count} / {record.limit}
-                  </ExpandableText>
+                  {record.count} / {record.limit}
                 </span>
-                <span data-label="Remaining">
-                  <ExpandableText lines={1}>{record.remaining}</ExpandableText>
-                </span>
+                <span data-label="Remaining">{record.remaining}</span>
                 <span data-label="Last start">
-                  <ExpandableText lines={1}>{record.last_started_at ? formatDateTime(record.last_started_at) : "None"}</ExpandableText>
+                  <Truncate>{record.last_started_at ? formatDateTime(record.last_started_at) : "None"}</Truncate>
                 </span>
                 <div className="admin-action-cell" data-label="Reset">
-                  <button
-                    className="secondary-action"
-                    type="button"
-                    onClick={() => reset.mutate(record.email)}
-                    disabled={reset.isPending}
-                  >
+                  <button className="secondary-action" type="button" onClick={() => reset.mutate(record.email)} disabled={reset.isPending}>
                     <RotateCcw aria-hidden="true" />
                     <span>Reset</span>
                   </button>
@@ -123,11 +121,22 @@ export function Admin() {
             ))}
           </div>
         ) : (
-          <div className="empty-panel">No limited users recorded today.</div>
+          <EmptyState>No limited users recorded today.</EmptyState>
         )}
         {reset.error && <div className="error-box">{reset.error.message}</div>}
       </section>
     </div>
+  );
+}
+
+function AdminHeader() {
+  return (
+    <header className="page-header">
+      <div>
+        <p className="eyebrow">Access control</p>
+        <h1>Admin console</h1>
+      </div>
+    </header>
   );
 }
 

--- a/web/ui/src/pages/Builder.test.ts
+++ b/web/ui/src/pages/Builder.test.ts
@@ -23,14 +23,13 @@ describe("buildPatch", () => {
     });
   });
 
-  it("honors the backend-provided step for editable fields", () => {
-    expect(inputStepForParameter({ kind: "number", step: 0.01 })).toBe(0.01);
-    expect(inputStepForParameter({ kind: "integer", step: 1000 })).toBe(1000);
-  });
-
-  it("falls back to a kind-appropriate step when none is provided", () => {
+  it("uses browser-safe numeric steps regardless of the backend step", () => {
+    // Non-integer fields must stay step="any" so backend defaults off the
+    // min+step grid don't trip HTML stepMismatch and block the run submit.
+    expect(inputStepForParameter({ kind: "number", step: 0.01 })).toBe("any");
     expect(inputStepForParameter({ kind: "number", step: null })).toBe("any");
+    // Integers step by 1, which is always grid-safe.
+    expect(inputStepForParameter({ kind: "integer", step: 1000 })).toBe(1);
     expect(inputStepForParameter({ kind: "integer", step: null })).toBe(1);
-    expect(inputStepForParameter({ kind: "number", step: 0 })).toBe("any");
   });
 });

--- a/web/ui/src/pages/Builder.test.ts
+++ b/web/ui/src/pages/Builder.test.ts
@@ -23,8 +23,14 @@ describe("buildPatch", () => {
     });
   });
 
-  it("uses browser-safe numeric steps for editable fields", () => {
-    expect(inputStepForParameter({ kind: "number", step: 1 })).toBe("any");
-    expect(inputStepForParameter({ kind: "integer", step: 1000 })).toBe(1);
+  it("honors the backend-provided step for editable fields", () => {
+    expect(inputStepForParameter({ kind: "number", step: 0.01 })).toBe(0.01);
+    expect(inputStepForParameter({ kind: "integer", step: 1000 })).toBe(1000);
+  });
+
+  it("falls back to a kind-appropriate step when none is provided", () => {
+    expect(inputStepForParameter({ kind: "number", step: null })).toBe("any");
+    expect(inputStepForParameter({ kind: "integer", step: null })).toBe(1);
+    expect(inputStepForParameter({ kind: "number", step: 0 })).toBe("any");
   });
 });

--- a/web/ui/src/pages/Builder.tsx
+++ b/web/ui/src/pages/Builder.tsx
@@ -1,10 +1,11 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, PlaySquare, ShieldCheck, SlidersHorizontal } from "lucide-react";
+import { CheckCircle2, ClipboardCheck, PlaySquare, ShieldCheck, SlidersHorizontal, XCircle } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
-import type { EditableParameter, SimulationDraft } from "../types";
+import { Truncate } from "../components/Truncate";
+import { PanelError, PanelLoading } from "../components/StateBlock";
+import type { DraftValidationResponse, EditableParameter, SimulationDraft } from "../types";
 
 const phaseOptions = [
   { value: "run", label: "Dry run" },
@@ -17,18 +18,26 @@ const phaseOptions = [
 
 export function Builder() {
   const navigate = useNavigate();
-  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const requestedCase = searchParams.get("case");
   const queryClient = useQueryClient();
   const session = useQuery({ queryKey: ["me"], queryFn: api.me, retry: false });
   const cases = useQuery({ queryKey: ["cases"], queryFn: api.cases });
-  const initialCase = new URLSearchParams(location.search).get("case");
-  const [caseName, setCaseName] = useState(initialCase ?? "");
+  const [caseName, setCaseName] = useState(requestedCase ?? "");
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [phases, setPhases] = useState(["run", "validate", "report"]);
   const [scenario, setScenario] = useState("");
   const [sweepSamples, setSweepSamples] = useState(65536);
   const [sweepSeed, setSweepSeed] = useState(42);
   const [preferGpu, setPreferGpu] = useState(true);
+
+  // Honor ?case= on mount and on in-app navigation to a different case.
+  useEffect(() => {
+    if (requestedCase && requestedCase !== caseName) {
+      setCaseName(requestedCase);
+      setValues({});
+    }
+  }, [requestedCase]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!caseName && cases.data?.[0]) {
@@ -59,6 +68,13 @@ export function Builder() {
       navigate(`/runs/${run.case_name}/${run.run_id}`);
     }
   });
+  const validation = useMutation({
+    mutationFn: () => api.validateDraft(caseName, buildPatch(values))
+  });
+
+  const sweepActive = phases.includes("transient-sweep");
+  const scenarioActive = phases.includes("transient") || phases.includes("transient-sweep");
+
   const quotaLabel = !session.data
     ? "Checking simulation access"
     : session.data.is_admin
@@ -72,7 +88,7 @@ export function Builder() {
       case_name: caseName,
       patch: buildPatch(values),
       phases,
-      scenario: scenario || null,
+      scenario: scenarioActive && scenario ? scenario : null,
       sweep_samples: sweepSamples,
       sweep_seed: sweepSeed,
       prefer_gpu: preferGpu
@@ -85,39 +101,53 @@ export function Builder() {
       <header className="page-header">
         <div>
           <p className="eyebrow">Draft-per-run inputs</p>
-          <h1>Simulation builder</h1>
+          <h1>Builder</h1>
         </div>
       </header>
       <form className="builder-layout" onSubmit={submit}>
         <section className="builder-controls">
           <label className="field">
             <span>Case</span>
-            <select value={caseName} onChange={(event) => setCaseName(event.target.value)}>
-              {cases.data?.map((item) => (
-                <option key={item.name} value={item.name}>
-                  {item.name}
-                </option>
-              ))}
-            </select>
+            {cases.isLoading ? (
+              <PanelLoading label="Loading cases" lines={1} />
+            ) : cases.isError ? (
+              <PanelError error={cases.error} onRetry={() => cases.refetch()} />
+            ) : (
+              <select value={caseName} onChange={(event) => { setCaseName(event.target.value); setValues({}); }}>
+                {cases.data?.map((item) => (
+                  <option key={item.name} value={item.name}>
+                    {item.name}
+                  </option>
+                ))}
+              </select>
+            )}
           </label>
-          <div className="phase-grid">
-            {phaseOptions.map((phase) => (
-              <label key={phase.value} className="check-tile">
-                <input
-                  type="checkbox"
-                  checked={phases.includes(phase.value)}
-                  onChange={(event) =>
-                    setPhases((current) => (event.target.checked ? [...current, phase.value] : current.filter((item) => item !== phase.value)))
-                  }
-                />
-                <span>{phase.label}</span>
-              </label>
-            ))}
+          <div className="control-group">
+            <div className="builder-section-label">Workflow phases</div>
+            <div className="phase-grid">
+              {phaseOptions.map((phase) => (
+                <label key={phase.value} className="check-tile">
+                  <input
+                    type="checkbox"
+                    checked={phases.includes(phase.value)}
+                    onChange={(event) =>
+                      setPhases((current) => (event.target.checked ? [...current, phase.value] : current.filter((item) => item !== phase.value)))
+                    }
+                  />
+                  <span>{phase.label}</span>
+                </label>
+              ))}
+            </div>
           </div>
-          <div className="builder-options">
+
+          <div className={`control-group${scenarioActive ? "" : " is-inactive"}`}>
+            <div className="builder-section-label">
+              <span>Transient scenario</span>
+              {!scenarioActive && <span className="inactive-hint">enable Transient phase</span>}
+            </div>
             <label className="field">
               <span>Scenario</span>
-              <select value={scenario} onChange={(event) => setScenario(event.target.value)}>
+              <select value={scenario} disabled={!scenarioActive} onChange={(event) => setScenario(event.target.value)}>
                 <option value="">Default</option>
                 {scenarios?.map((item) => (
                   <option key={item} value={item}>
@@ -126,65 +156,140 @@ export function Builder() {
                 ))}
               </select>
             </label>
-            <label className="field">
-              <span>Sweep samples</span>
-              <input type="number" min={1} max={65536} value={sweepSamples} onChange={(event) => setSweepSamples(Number(event.target.value))} />
-            </label>
-            <label className="field">
-              <span>Sweep seed</span>
-              <input type="number" min={0} value={sweepSeed} onChange={(event) => setSweepSeed(Number(event.target.value))} />
-            </label>
-            <label className="check-line">
-              <input type="checkbox" checked={preferGpu} onChange={(event) => setPreferGpu(event.target.checked)} />
-              <span>Use GPU for sweep</span>
-            </label>
           </div>
-          <button className="primary-action wide" type="submit" disabled={startDisabled}>
-            <PlaySquare aria-hidden="true" />
-            <span>{createRun.isPending ? "Starting..." : "Start run"}</span>
-          </button>
-          <div className={session.data?.can_start_run === false ? "error-box" : "draft-note"}>
+
+          <div className={`control-group${sweepActive ? "" : " is-inactive"}`}>
+            <div className="builder-section-label">
+              <span>Uncertainty sweep</span>
+              {!sweepActive && <span className="inactive-hint">enable Sweep phase</span>}
+            </div>
+            <div className="builder-options">
+              <label className="field">
+                <span>Sweep samples</span>
+                <input type="number" min={1} max={65536} value={sweepSamples} disabled={!sweepActive} onChange={(event) => setSweepSamples(Number(event.target.value))} />
+              </label>
+              <label className="field">
+                <span>Sweep seed</span>
+                <input type="number" min={0} value={sweepSeed} disabled={!sweepActive} onChange={(event) => setSweepSeed(Number(event.target.value))} />
+              </label>
+              <label className="check-line">
+                <input type="checkbox" checked={preferGpu} disabled={!sweepActive} onChange={(event) => setPreferGpu(event.target.checked)} />
+                <span>Use GPU for sweep</span>
+              </label>
+            </div>
+          </div>
+
+          <div className="builder-actions">
+            <button
+              className="secondary-action wide"
+              type="button"
+              disabled={!caseName || validation.isPending}
+              onClick={() => validation.mutate()}
+            >
+              <ClipboardCheck aria-hidden="true" />
+              <span>{validation.isPending ? "Checking…" : "Check inputs"}</span>
+            </button>
+            <button className="primary-action wide" type="submit" disabled={startDisabled}>
+              <PlaySquare aria-hidden="true" />
+              <span>{createRun.isPending ? "Starting…" : "Start run"}</span>
+            </button>
+          </div>
+
+          <ValidationResult data={validation.data} isError={validation.isError} error={validation.error} />
+
+          <div className={`quota-note${session.data?.can_start_run === false ? " blocked" : ""}`}>
             <ShieldCheck aria-hidden="true" />
-            <span>{quotaLabel}</span>
+            <span className="quota-count">{quotaLabel}</span>
           </div>
           {createRun.error && <div className="error-box">{createRun.error.message}</div>}
         </section>
+
         <section className="builder-parameters">
           <div className="section-title">
             <SlidersHorizontal aria-hidden="true" />
             <h2>Input parameters</h2>
           </div>
-          {[...groupedParameters.entries()].map(([group, parameters]) => (
-            <div key={group} className="parameter-band">
-              <h3>{group}</h3>
-              <div className="input-grid">
-                {parameters.map((parameter) => (
-                  <label key={parameter.path} className="field">
-                    <ExpandableText className="field-title" insideInteractive lines={2}>
-                      {parameter.label}
-                    </ExpandableText>
-                    <input
-                      type="number"
-                      min={parameter.minimum ?? undefined}
-                      max={parameter.maximum ?? undefined}
-                      step={inputStepForParameter(parameter)}
-                      value={String(values[parameter.path] ?? parameter.value ?? "")}
-                      onChange={(event) => setValues((current) => ({ ...current, [parameter.path]: Number(event.target.value) }))}
-                    />
-                    <ExpandableText className="field-hint" insideInteractive lines={1}>
-                      {parameter.unit ?? parameter.path}
-                    </ExpandableText>
-                  </label>
-                ))}
+          {detail.isLoading ? (
+            <PanelLoading label="Loading parameters" lines={8} />
+          ) : detail.isError ? (
+            <PanelError error={detail.error} onRetry={() => detail.refetch()} />
+          ) : (
+            <>
+              {[...groupedParameters.entries()].map(([group, parameters]) => (
+                <div key={group} className="parameter-band">
+                  <h3>{group}</h3>
+                  <div className="input-grid">
+                    {parameters.map((parameter) => (
+                      <label key={parameter.path} className="field">
+                        <Truncate className="field-title" lines={2}>
+                          {parameter.label}
+                        </Truncate>
+                        {parameter.options?.length ? (
+                          <select
+                            value={String(values[parameter.path] ?? parameter.value ?? "")}
+                            onChange={(event) => setValues((current) => ({ ...current, [parameter.path]: event.target.value }))}
+                          >
+                            {parameter.options.map((option) => (
+                              <option key={option} value={option}>
+                                {option}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <input
+                            type="number"
+                            min={parameter.minimum ?? undefined}
+                            max={parameter.maximum ?? undefined}
+                            step={inputStepForParameter(parameter)}
+                            value={String(values[parameter.path] ?? parameter.value ?? "")}
+                            onChange={(event) => setValues((current) => ({ ...current, [parameter.path]: Number(event.target.value) }))}
+                          />
+                        )}
+                        <Truncate className="field-hint">{parameter.unit ?? parameter.path}</Truncate>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))}
+              <div className="draft-note">
+                <CheckCircle2 aria-hidden="true" />
+                <span>Submitted values are written to the new bundle snapshot only — your source configs are never modified.</span>
               </div>
-            </div>
-          ))}
-          <div className="draft-note">
-            <CheckCircle2 aria-hidden="true" />
-            <span>Submitted values are written to the new bundle snapshot only.</span>
-          </div>
+            </>
+          )}
         </section>
       </form>
+    </div>
+  );
+}
+
+function ValidationResult({ data, isError, error }: { data?: DraftValidationResponse; isError: boolean; error: Error | null }) {
+  if (isError) {
+    return (
+      <div className="validation-result invalid" role="status">
+        <XCircle aria-hidden="true" />
+        <div className="validation-body">
+          <strong>Could not check inputs</strong>
+          <span>{error?.message ?? "Validation request failed."}</span>
+        </div>
+      </div>
+    );
+  }
+  if (!data) return null;
+  const { valid, message, normalized_yaml } = data;
+  return (
+    <div className={`validation-result ${valid ? "valid" : "invalid"}`} role="status">
+      {valid ? <CheckCircle2 aria-hidden="true" /> : <XCircle aria-hidden="true" />}
+      <div className="validation-body">
+        <strong>{valid ? "Inputs are valid" : "Inputs need attention"}</strong>
+        <span>{message}</span>
+        {valid && normalized_yaml && (
+          <details>
+            <summary>Preview normalized case</summary>
+            <pre className="text-preview">{normalized_yaml}</pre>
+          </details>
+        )}
+      </div>
     </div>
   );
 }
@@ -220,5 +325,8 @@ export function buildPatch(values: Record<string, unknown>): Record<string, unkn
 }
 
 export function inputStepForParameter(parameter: Pick<EditableParameter, "kind" | "step">): number | "any" {
+  if (parameter.step != null && Number.isFinite(parameter.step) && parameter.step > 0) {
+    return parameter.step;
+  }
   return parameter.kind === "integer" ? 1 : "any";
 }

--- a/web/ui/src/pages/Builder.tsx
+++ b/web/ui/src/pages/Builder.tsx
@@ -325,8 +325,10 @@ export function buildPatch(values: Record<string, unknown>): Record<string, unkn
 }
 
 export function inputStepForParameter(parameter: Pick<EditableParameter, "kind" | "step">): number | "any" {
-  if (parameter.step != null && Number.isFinite(parameter.step) && parameter.step > 0) {
-    return parameter.step;
-  }
+  // Non-integer fields use step="any": the backend step (e.g. 0.01) combined
+  // with the input's min forms an HTML validation grid, and shipped defaults
+  // (e.g. primary_cp_kj_kgk: 4.2 against min 0.001 / step 0.01) don't lie on it,
+  // so the browser would flag an untouched field as stepMismatch and block the
+  // Start-run submit. Integers step by 1, which is always grid-safe.
   return parameter.kind === "integer" ? 1 : "any";
 }

--- a/web/ui/src/pages/Cases.tsx
+++ b/web/ui/src/pages/Cases.tsx
@@ -1,17 +1,20 @@
-import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { useMemo } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Atom, BookOpen, Box, ChevronRight, Settings2 } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
+import { Truncate } from "../components/Truncate";
+import { StatusBadge } from "../components/StatusBadge";
+import { PanelError, PanelLoading, EmptyState } from "../components/StateBlock";
 import { RunOutputSections } from "../components/RunOutputSections";
 import { hasViewableGeometry } from "../geometryArtifacts";
 import type { EditableParameter, RunRecord } from "../types";
 
 export function Cases() {
+  const params = useParams();
+  const navigate = useNavigate();
   const cases = useQuery({ queryKey: ["cases"], queryFn: api.cases });
-  const [selected, setSelected] = useState<string | null>(null);
-  const selectedName = selected ?? cases.data?.[0]?.name;
+  const selectedName = params.caseName ?? cases.data?.[0]?.name;
   const detail = useQuery({
     queryKey: ["case", selectedName],
     queryFn: () => api.caseDetail(selectedName!),
@@ -36,31 +39,48 @@ export function Cases() {
       <section className="list-panel">
         <div className="section-title">
           <Atom aria-hidden="true" />
-          <h1>Simulation types</h1>
+          <h1>Simulations</h1>
         </div>
-        <div className="case-list">
-          {cases.data?.map((item) => (
-            <button key={item.name} type="button" className={item.name === selectedName ? "selected" : ""} onClick={() => setSelected(item.name)}>
-              <ExpandableText className="list-title" insideInteractive lines={1}>
-                {String(item.reactor.name ?? item.name)}
-              </ExpandableText>
-              <ExpandableText className="list-meta" insideInteractive lines={1}>
-                {simulationLabel(item.reactor)}
-              </ExpandableText>
-              <ChevronRight aria-hidden="true" />
-            </button>
-          ))}
-        </div>
+        {cases.isLoading ? (
+          <PanelLoading label="Loading simulations" lines={6} />
+        ) : cases.isError ? (
+          <PanelError error={cases.error} onRetry={() => cases.refetch()} />
+        ) : cases.data?.length ? (
+          <div className="case-list">
+            {cases.data.map((item) => {
+              const isSelected = item.name === selectedName;
+              return (
+                <button
+                  key={item.name}
+                  type="button"
+                  className={isSelected ? "selected" : ""}
+                  aria-pressed={isSelected}
+                  onClick={() => navigate(`/cases/${item.name}`)}
+                >
+                  <Truncate className="list-title">{String(item.reactor.name ?? item.name)}</Truncate>
+                  <Truncate className="list-meta">{simulationLabel(item.reactor)}</Truncate>
+                  <ChevronRight aria-hidden="true" />
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <EmptyState icon={Atom}>No simulation types found.</EmptyState>
+        )}
       </section>
 
       <section className="detail-panel">
-        {detail.data && (
+        {detail.isLoading ? (
+          <PanelLoading label="Loading simulation" lines={8} tall />
+        ) : detail.isError ? (
+          <PanelError error={detail.error} onRetry={() => detail.refetch()} tall />
+        ) : detail.data ? (
           <>
             <header className="page-header compact">
               <div>
                 <p className="eyebrow">{String(detail.data.reactor.family ?? "MSR case")}</p>
                 <h1>
-                  <ExpandableText lines={2}>{String(detail.data.reactor.name ?? detail.data.name)}</ExpandableText>
+                  <Truncate lines={2}>{String(detail.data.reactor.name ?? detail.data.name)}</Truncate>
                 </h1>
               </div>
               <Link className="primary-action" to={`/builder?case=${detail.data.name}`}>
@@ -79,13 +99,11 @@ export function Cases() {
                 <div>
                   <h2>Latest detailed output</h2>
                   {latestRunRef && (
-                    <ExpandableText className="run-meta" lines={1}>
-                      {latestRunRef.run_id}
-                    </ExpandableText>
+                    <Truncate className="run-meta">{latestRunRef.run_id}</Truncate>
                   )}
                 </div>
                 <div>
-                  {latestRunRef && <mark>{latestRun.data?.status ?? latestRunRef.status}</mark>}
+                  {latestRunRef && <StatusBadge status={latestRun.data?.status ?? latestRunRef.status} />}
                   {latestRun.data && hasViewableGeometry(latestRun.data) && (
                     <Link className="secondary-action" to={`/viewer/${latestRun.data.case_name}/${latestRun.data.run_id}`}>
                       <Box aria-hidden="true" />
@@ -95,13 +113,17 @@ export function Cases() {
                 </div>
               </div>
               {latestRunRef ? (
-                latestRun.data ? (
+                latestRun.isLoading ? (
+                  <PanelLoading label="Loading latest output" lines={4} />
+                ) : latestRun.isError ? (
+                  <PanelError error={latestRun.error} onRetry={() => latestRun.refetch()} />
+                ) : latestRun.data ? (
                   <RunOutputSections sections={latestRun.data.output_sections ?? []} />
                 ) : (
-                  <div className="empty-panel">Loading latest simulation output...</div>
+                  <EmptyState>No detailed output was recorded for this run.</EmptyState>
                 )
               ) : (
-                <div className="empty-panel">No result bundle has been created for this simulation type.</div>
+                <EmptyState>No result bundle has been created for this simulation type.</EmptyState>
               )}
             </section>
             <div className="two-column supporting-grid">
@@ -110,13 +132,17 @@ export function Cases() {
                   <BookOpen aria-hidden="true" />
                   <h2>Relevant docs</h2>
                 </div>
-                <div className="doc-links">
-                  {detail.data.docs.map((doc) => (
-                    <Link key={doc.slug} to={`/docs/${doc.slug}`}>
-                      <span className="list-title">{doc.title}</span>
-                    </Link>
-                  ))}
-                </div>
+                {detail.data.docs.length ? (
+                  <div className="doc-links">
+                    {detail.data.docs.map((doc) => (
+                      <Link key={doc.slug} to={`/docs/${doc.slug}`}>
+                        <Truncate className="list-title">{doc.title}</Truncate>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <EmptyState icon={BookOpen}>No linked documents.</EmptyState>
+                )}
               </div>
               <div className="panel">
                 <h2>Simulation model</h2>
@@ -135,15 +161,11 @@ export function Cases() {
                   <div className="parameter-table">
                     {parameters.slice(0, 12).map((parameter) => (
                       <div key={parameter.path}>
-                        <ExpandableText className="parameter-label" lines={2}>
+                        <Truncate className="parameter-label" lines={2}>
                           {parameter.label}
-                        </ExpandableText>
-                        <ExpandableText className="parameter-value" lines={1}>
-                          {String(parameter.value)}
-                        </ExpandableText>
-                        <ExpandableText className="parameter-meta" lines={1}>
-                          {parameter.unit ?? parameter.path}
-                        </ExpandableText>
+                        </Truncate>
+                        <Truncate className="parameter-value">{String(parameter.value)}</Truncate>
+                        <Truncate className="parameter-meta">{parameter.unit ?? parameter.path}</Truncate>
                       </div>
                     ))}
                   </div>
@@ -151,6 +173,8 @@ export function Cases() {
               ))}
             </div>
           </>
+        ) : (
+          <EmptyState tall icon={Atom}>Select a simulation to view its outputs.</EmptyState>
         )}
       </section>
     </div>
@@ -173,14 +197,14 @@ function Fact({ label, value, unit }: { label: string; value: unknown; unit?: st
     <div>
       <dt>{label}</dt>
       <dd>
-        <ExpandableText lines={1}>{formatFact(value, unit)}</ExpandableText>
+        <Truncate>{formatFact(value, unit)}</Truncate>
       </dd>
     </div>
   );
 }
 
 function simulationLabel(reactor: Record<string, unknown>) {
-  return [reactor.family, reactor.mode].filter(Boolean).join(" / ") || "reactor simulation";
+  return [reactor.family, reactor.mode].filter(Boolean).join(" · ") || "reactor simulation";
 }
 
 function formatFact(value: unknown, unit?: string) {

--- a/web/ui/src/pages/Dashboard.tsx
+++ b/web/ui/src/pages/Dashboard.tsx
@@ -1,8 +1,11 @@
+import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Activity, Atom, CheckCircle2, Clock, FileText, PlaySquare } from "lucide-react";
+import { Activity, Atom, CheckCircle2, Clock, FileText, Gauge, PlaySquare } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
+import { Truncate } from "../components/Truncate";
+import { PanelError, PanelLoading, EmptyState } from "../components/StateBlock";
+import type { RunRecord } from "../types";
 
 export function Dashboard() {
   const cases = useQuery({ queryKey: ["cases"], queryFn: api.cases });
@@ -25,7 +28,7 @@ export function Dashboard() {
         <div>
           <p className="eyebrow">Shared lab server</p>
           <h1>
-            <ExpandableText lines={2}>Thorium molten-salt reactor simulation</ExpandableText>
+            <Truncate lines={2}>Thorium molten-salt reactor simulation</Truncate>
           </h1>
         </div>
         <Link className="primary-action" to="/builder">
@@ -37,21 +40,17 @@ export function Dashboard() {
       <section className="hero-band">
         <div className="hero-copy">
           <h2>
-            <ExpandableText lines={2}>{String(latestCase?.reactor?.name ?? latestCase?.name ?? "Simulation workspace")}</ExpandableText>
+            <Truncate lines={2}>{String(latestCase?.reactor?.name ?? latestCase?.name ?? "Simulation workspace")}</Truncate>
           </h2>
           <div className="stat-row">
-            <Stat icon={Atom} label="Simulation types" value={caseCount} />
-            <Stat icon={Activity} label="Result bundles" value={runCount} />
-            <Stat icon={CheckCircle2} label="Completed" value={completedCount} />
-            <Stat icon={FileText} label="Docs" value={docCount} />
+            <Stat icon={Atom} label="Simulation types" value={statValue(cases.isLoading, caseCount)} />
+            <Stat icon={Activity} label="Result bundles" value={statValue(runs.isLoading, runCount)} />
+            <Stat icon={CheckCircle2} label="Completed" value={statValue(runs.isLoading, completedCount)} />
+            <Stat icon={FileText} label="Docs" value={statValue(docs.isLoading, docCount)} />
           </div>
         </div>
         <div className="hero-media">
-          {featured ? (
-            <img src={featured.url} alt={featured.label} />
-          ) : (
-            <ReactorReadout cases={caseCount} docs={docCount} runs={runCount} completed={completedCount} />
-          )}
+          {featured ? <img src={featured.url} alt={featured.label} /> : <ReactorReadout runs={runs.data} docCount={docCount} caseCount={caseCount} />}
         </div>
       </section>
 
@@ -61,19 +60,23 @@ export function Dashboard() {
             <Clock aria-hidden="true" />
             <h2>Simulation portfolio</h2>
           </div>
-          {cases.data?.length ? (
+          {cases.isLoading ? (
+            <PanelLoading label="Loading simulations" lines={4} />
+          ) : cases.isError ? (
+            <PanelError error={cases.error} onRetry={() => cases.refetch()} />
+          ) : cases.data?.length ? (
             <div className="doc-links">
               {cases.data.slice(0, 6).map((item) => (
-                <Link key={item.name} to="/cases">
-                  <span className="list-title">{String(item.reactor.name ?? item.name)}</span>
-                  <small className="list-meta">
-                    {[item.reactor.family, item.reactor.mode, item.latest_run?.status].filter(Boolean).join(" / ") || item.name}
-                  </small>
+                <Link key={item.name} to={`/cases/${item.name}`}>
+                  <Truncate className="list-title">{String(item.reactor.name ?? item.name)}</Truncate>
+                  <Truncate className="list-meta">
+                    {[item.reactor.family, item.reactor.mode, item.latest_run?.status].filter(Boolean).join(" · ") || item.name}
+                  </Truncate>
                 </Link>
               ))}
             </div>
           ) : (
-            <div className="empty-panel">No simulation types found.</div>
+            <EmptyState icon={Atom}>No simulation types found.</EmptyState>
           )}
           <Link className="text-link" to="/cases">
             Open simulation outputs
@@ -84,21 +87,33 @@ export function Dashboard() {
             <FileText aria-hidden="true" />
             <h2>Science library</h2>
           </div>
-          <div className="doc-links">
-            {docs.data?.slice(0, 6).map((doc) => (
-              <Link key={doc.slug} to={`/docs/${doc.slug}`}>
-                <span className="list-title">{doc.title}</span>
-                <small className="list-meta">{doc.path}</small>
-              </Link>
-            ))}
-          </div>
+          {docs.isLoading ? (
+            <PanelLoading label="Loading documents" lines={4} />
+          ) : docs.isError ? (
+            <PanelError error={docs.error} onRetry={() => docs.refetch()} />
+          ) : docs.data?.length ? (
+            <div className="doc-links">
+              {docs.data.slice(0, 6).map((doc) => (
+                <Link key={doc.slug} to={`/docs/${doc.slug}`}>
+                  <Truncate className="list-title">{doc.title}</Truncate>
+                  <Truncate className="list-meta">{doc.path}</Truncate>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <EmptyState icon={FileText}>No documents found.</EmptyState>
+          )}
         </div>
       </section>
     </div>
   );
 }
 
-function Stat({ icon: Icon, label, value }: { icon: typeof Atom; label: string; value: number }) {
+function statValue(isLoading: boolean, value: number): ReactNode {
+  return isLoading ? "—" : value;
+}
+
+function Stat({ icon: Icon, label, value }: { icon: typeof Atom; label: string; value: ReactNode }) {
   return (
     <div className="stat-item">
       <Icon aria-hidden="true" />
@@ -108,33 +123,75 @@ function Stat({ icon: Icon, label, value }: { icon: typeof Atom; label: string; 
   );
 }
 
-function ReactorReadout({ cases, completed, docs, runs }: { cases: number; completed: number; docs: number; runs: number }) {
+const TONE_VAR: Record<string, string> = { ok: "var(--ok)", info: "var(--info)", danger: "var(--danger)", neutral: "var(--line-strong)" };
+
+function statusBuckets(runList: RunRecord[]) {
+  const counts = { ok: 0, info: 0, danger: 0, neutral: 0 };
+  for (const run of runList) {
+    if (run.status === "completed") counts.ok += 1;
+    else if (run.status === "running" || run.status === "queued") counts.info += 1;
+    else if (run.status === "failed" || run.status === "canceled") counts.danger += 1;
+    else counts.neutral += 1;
+  }
+  return [
+    { tone: "ok" as const, label: "Completed", count: counts.ok },
+    { tone: "info" as const, label: "Running", count: counts.info },
+    { tone: "danger" as const, label: "Failed", count: counts.danger },
+    { tone: "neutral" as const, label: "Other", count: counts.neutral }
+  ].filter((bucket) => bucket.count > 0);
+}
+
+function ReactorReadout({ runs, caseCount, docCount }: { runs?: RunRecord[]; caseCount: number; docCount: number }) {
+  const runList = runs ?? [];
+  const completed = runList.filter((run) => run.status === "completed").length;
+  const buckets = statusBuckets(runList);
+  const total = runList.length || 1;
+
   return (
     <div className="reactor-readout" aria-label="Repository reactor readout">
-      <div className="readout-grid" aria-hidden="true">
-        <span />
-        <span />
-        <span />
-        <span />
-        <span />
-        <span />
+      <div className="status-strip">
+        <div className="readout-caption">
+          <Gauge aria-hidden="true" />
+          <span>Run status</span>
+        </div>
+        {runList.length ? (
+          <>
+            <div className="status-strip-bar" role="img" aria-label={buckets.map((bucket) => `${bucket.count} ${bucket.label}`).join(", ")}>
+              {buckets.map((bucket) => (
+                <span key={bucket.tone} className={`seg tone-${bucket.tone}`} style={{ width: `${(bucket.count / total) * 100}%` }} />
+              ))}
+            </div>
+            <div className="status-strip-legend">
+              {buckets.map((bucket) => (
+                <span key={bucket.tone}>
+                  <i style={{ background: TONE_VAR[bucket.tone] }} />
+                  {bucket.label} · {bucket.count}
+                </span>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="status-strip-legend">
+            <span>No result bundles yet.</span>
+          </div>
+        )}
       </div>
       <div className="readout-table">
         <div>
-          <span>Case index</span>
-          <strong>{cases}</strong>
+          <span>Simulation types</span>
+          <strong>{caseCount}</strong>
         </div>
         <div>
           <span>Run bundles</span>
-          <strong>{runs}</strong>
+          <strong>{runList.length}</strong>
         </div>
         <div>
-          <span>Validated</span>
+          <span>Completed</span>
           <strong>{completed}</strong>
         </div>
         <div>
           <span>Science notes</span>
-          <strong>{docs}</strong>
+          <strong>{docCount}</strong>
         </div>
       </div>
     </div>

--- a/web/ui/src/pages/Docs.tsx
+++ b/web/ui/src/pages/Docs.tsx
@@ -1,32 +1,30 @@
 import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { BookOpen, ListTree, Sigma } from "lucide-react";
+import { BookOpen, ListTree } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
-import { Markdown } from "../components/Markdown";
-
-const formulaCards = [
-  {
-    label: "Loop energy",
-    expression: "$$Q = \\dot m c_p \\Delta T$$"
-  },
-  {
-    label: "Hydraulic budget",
-    expression: "$$\\Delta p = f\\frac{L}{D}\\frac{\\rho u^2}{2}+\\sum_j K_j\\frac{\\rho u^2}{2}+\\rho g\\Delta z$$"
-  },
-  {
-    label: "Precursor transport",
-    expression: "$$\\frac{dC_i}{dt}+\\nabla\\cdot(uC_i)=\\nabla\\cdot(D_i\\nabla C_i)+S_{i,f}-\\lambda_i C_i$$"
-  }
-];
+import { Truncate } from "../components/Truncate";
+import { PanelError, PanelLoading, EmptyState } from "../components/StateBlock";
+import { Markdown, makeSlugger } from "../components/Markdown";
 
 export function Docs() {
   const params = useParams();
   const docs = useQuery({ queryKey: ["docs"], queryFn: api.docs });
   const slug = params.slug ?? docs.data?.[0]?.slug;
   const doc = useQuery({ queryKey: ["doc", slug], queryFn: () => api.doc(slug!), enabled: Boolean(slug) });
-  const headings = useMemo(() => doc.data?.headings.slice(1, 9) ?? [], [doc.data]);
+  const outline = useMemo(() => {
+    if (!doc.data) return [];
+    // Slug the full heading list in order (same algorithm the renderer uses) so
+    // ids line up, including de-duplication of repeated heading text; the first
+    // heading is the page title, shown in the header rather than the outline.
+    const slug = makeSlugger();
+    return doc.data.headings.map((heading) => ({ text: heading, id: slug(heading) })).slice(1, 12);
+  }, [doc.data]);
+  const readMeta = useMemo(() => {
+    if (!doc.data) return null;
+    const words = doc.data.content.trim().split(/\s+/).filter(Boolean).length;
+    return { words, minutes: Math.max(1, Math.round(words / 200)) };
+  }, [doc.data]);
   const docCount = docs.data?.length ?? 0;
 
   return (
@@ -36,65 +34,83 @@ export function Docs() {
           <BookOpen aria-hidden="true" />
           <div>
             <h1>Science</h1>
-            <span>{docCount} living notes</span>
+            <span>{docs.isLoading ? "Loading…" : `${docCount} reference notes`}</span>
           </div>
         </div>
-        <div className="doc-links">
-          {docs.data?.map((item) => (
-            <Link key={item.slug} className={item.slug === slug ? "selected" : ""} to={`/docs/${item.slug}`}>
-              <span className="list-title">{item.title}</span>
-              <small className="list-meta">{item.path}</small>
-            </Link>
-          ))}
-        </div>
+        {docs.isLoading ? (
+          <PanelLoading label="Loading documents" lines={6} />
+        ) : docs.isError ? (
+          <PanelError error={docs.error} onRetry={() => docs.refetch()} />
+        ) : docs.data?.length ? (
+          <div className="doc-links">
+            {docs.data.map((item) => {
+              const isSelected = item.slug === slug;
+              return (
+                <Link key={item.slug} className={isSelected ? "selected" : ""} aria-current={isSelected ? "page" : undefined} to={`/docs/${item.slug}`}>
+                  <Truncate className="list-title">{item.title}</Truncate>
+                  <Truncate className="list-meta">{item.path}</Truncate>
+                </Link>
+              );
+            })}
+          </div>
+        ) : (
+          <EmptyState icon={BookOpen}>No documents found.</EmptyState>
+        )}
       </section>
       <section className="detail-panel docs-panel">
-        {doc.data && (
+        {doc.isLoading ? (
+          <PanelLoading label="Loading document" lines={10} tall />
+        ) : doc.isError ? (
+          <PanelError error={doc.error} onRetry={() => doc.refetch()} tall />
+        ) : doc.data ? (
           <>
             <header className="page-header compact science-header">
               <div>
                 <p className="eyebrow">
-                  <ExpandableText lines={1}>{doc.data.path}</ExpandableText>
+                  <Truncate>{doc.data.path}</Truncate>
                 </p>
                 <h1>
-                  <ExpandableText lines={2}>{doc.data.title}</ExpandableText>
+                  <Truncate lines={2}>{doc.data.title}</Truncate>
                 </h1>
                 <div className="science-meta">
                   <span>{doc.data.headings.length} sections</span>
-                  <span>Repository note</span>
-                  <span>Equation notation</span>
+                  {readMeta && <span>{readMeta.words.toLocaleString()} words</span>}
+                  {readMeta && <span>{readMeta.minutes} min read</span>}
                 </div>
               </div>
             </header>
             <div className="docs-layout">
-              <Markdown className="markdown-body science-article" content={doc.data.content} />
-              <aside className="science-rail">
-                <section className="toc">
-                  <div className="section-title">
-                    <ListTree aria-hidden="true" />
-                    <h2>Outline</h2>
-                  </div>
-                  {headings.map((heading) => (
-                    <ExpandableText className="toc-item" key={heading} lines={1}>
-                      {heading}
-                    </ExpandableText>
-                  ))}
-                </section>
-                <section className="formula-stack">
-                  <div className="section-title">
-                    <Sigma aria-hidden="true" />
-                    <h2>Core Relations</h2>
-                  </div>
-                  {formulaCards.map((card) => (
-                    <div className="formula-card" key={card.label}>
-                      <span>{card.label}</span>
-                      <Markdown className="formula-math" content={card.expression} />
+              <Markdown className="markdown-body science-article" content={doc.data.content} anchors />
+              {outline.length > 0 && (
+                <aside className="science-rail">
+                  <nav className="toc" aria-label="Document outline">
+                    <div className="section-title">
+                      <ListTree aria-hidden="true" />
+                      <h2>Outline</h2>
                     </div>
-                  ))}
-                </section>
-              </aside>
+                    {outline.map((heading) => (
+                      <a
+                        key={heading.id}
+                        className="toc-item"
+                        href={`#${heading.id}`}
+                        onClick={(event) => {
+                          const target = document.getElementById(heading.id);
+                          if (target) {
+                            event.preventDefault();
+                            target.scrollIntoView({ behavior: "smooth", block: "start" });
+                          }
+                        }}
+                      >
+                        {heading.text}
+                      </a>
+                    ))}
+                  </nav>
+                </aside>
+              )}
             </div>
           </>
+        ) : (
+          <EmptyState tall icon={BookOpen}>Select a document to read.</EmptyState>
         )}
       </section>
     </div>

--- a/web/ui/src/pages/Runs.tsx
+++ b/web/ui/src/pages/Runs.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Activity, CheckCircle2, Clock, XCircle } from "lucide-react";
+import { Activity, ArrowLeft, Atom, CheckCircle2, Clock, XCircle } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
+import { Truncate } from "../components/Truncate";
+import { StatusBadge } from "../components/StatusBadge";
+import { ProgressBar } from "../components/ProgressBar";
+import { PanelError, PanelLoading, EmptyState } from "../components/StateBlock";
 import { RunDataExplorer } from "../components/RunDataExplorer";
 import { RunOutputSections } from "../components/RunOutputSections";
 import { RunArtifacts } from "../components/RunArtifacts";
@@ -35,6 +38,9 @@ export function Runs() {
     return () => source.close();
   }, [detail.data, queryClient]);
 
+  const active = detail.data && ["queued", "running"].includes(detail.data.status);
+  const progress = detail.data?.latest_event?.progress;
+
   return (
     <div className="page split-page">
       <section className="list-panel">
@@ -42,53 +48,88 @@ export function Runs() {
           <Activity aria-hidden="true" />
           <h1>Runs</h1>
         </div>
-        <div className="run-list">
-          {runs.data?.map((run) => (
-            <button
-              key={`${run.case_name}-${run.run_id}`}
-              type="button"
-              className={run.case_name === selected?.caseName && run.run_id === selected.runId ? "selected" : ""}
-              onClick={() => navigate(`/runs/${run.case_name}/${run.run_id}`)}
-            >
-              <ExpandableText className="list-title" insideInteractive lines={1}>
-                {run.case_name}
-              </ExpandableText>
-              <ExpandableText className="list-meta" insideInteractive lines={1}>
-                {run.run_id}
-              </ExpandableText>
-              <mark>{run.status}</mark>
-            </button>
-          ))}
-        </div>
+        {runs.isLoading ? (
+          <PanelLoading label="Loading runs" lines={6} />
+        ) : runs.isError ? (
+          <PanelError error={runs.error} onRetry={() => runs.refetch()} />
+        ) : runs.data?.length ? (
+          <div className="run-list">
+            {runs.data.map((run) => {
+              const isSelected = run.case_name === selected?.caseName && run.run_id === selected.runId;
+              return (
+                <button
+                  key={`${run.case_name}-${run.run_id}`}
+                  type="button"
+                  className={isSelected ? "selected" : ""}
+                  aria-pressed={isSelected}
+                  onClick={() => navigate(`/runs/${run.case_name}/${run.run_id}`)}
+                >
+                  <Truncate className="list-title">{run.case_name}</Truncate>
+                  <Truncate className="list-meta">{run.run_id}</Truncate>
+                  <StatusBadge status={run.status} />
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <EmptyState icon={Activity}>No runs yet. Start one from the Builder.</EmptyState>
+        )}
       </section>
       <section className="detail-panel">
-        {detail.data ? (
+        {detail.isLoading ? (
+          <PanelLoading label="Loading run" lines={8} tall />
+        ) : detail.isError ? (
+          <PanelError error={detail.error} onRetry={() => detail.refetch()} tall />
+        ) : detail.data ? (
           <>
             <header className="page-header compact">
               <div>
+                {params.runId && (
+                  <Link className="back-link" to="/runs">
+                    <ArrowLeft aria-hidden="true" />
+                    All runs
+                  </Link>
+                )}
                 <p className="eyebrow">{detail.data.case_name}</p>
                 <h1>
-                  <ExpandableText lines={2}>{detail.data.run_id}</ExpandableText>
+                  <Truncate lines={2}>{detail.data.run_id}</Truncate>
                 </h1>
               </div>
-              {hasViewableGeometry(detail.data) && (
-                <Link className="secondary-action" to={`/viewer/${detail.data.case_name}/${detail.data.run_id}`}>
-                  Open 3D
-                </Link>
-              )}
+              <div className="output-focus-title" style={{ flex: "0 0 auto" }}>
+                <StatusBadge status={detail.data.status} />
+                {hasViewableGeometry(detail.data) && (
+                  <Link className="secondary-action" to={`/viewer/${detail.data.case_name}/${detail.data.run_id}`}>
+                    Open 3D
+                  </Link>
+                )}
+              </div>
             </header>
-            <div className="timeline">
-              {(detail.data.command_plan.length ? detail.data.command_plan : ["build", "run", "validate", "report"]).map((phase) => (
-                <div key={phase} className={phase === detail.data?.phase ? "current" : ""}>
-                  {iconForPhase(detail.data!.status, phase === detail.data!.phase)}
-                  <span>{phase}</span>
-                </div>
-              ))}
-            </div>
-            {detail.data.latest_event && (
+            {detail.data.command_plan.length ? (
+              <div className="timeline">
+                {detail.data.command_plan.map((phase) => (
+                  <div key={phase} className={phaseClass(detail.data!.status, phase === detail.data!.phase)}>
+                    {iconForPhase(detail.data!.status, phase === detail.data!.phase)}
+                    <span>{phase}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <EmptyState icon={Clock}>No phase plan recorded for this run.</EmptyState>
+            )}
+            {(active || detail.data.latest_event) && (
               <div className="event-banner">
                 <Clock aria-hidden="true" />
-                <ExpandableText lines={2}>{detail.data.latest_event.message}</ExpandableText>
+                <div className="event-body">
+                  {detail.data.latest_event && <Truncate lines={2}>{detail.data.latest_event.message}</Truncate>}
+                  {active && (
+                    <div className="progress-line">
+                      <ProgressBar value={progress} label="Run progress" />
+                      {progress != null && Number.isFinite(progress) && (
+                        <span className="progress-percent">{Math.round(progress * 100)}%</span>
+                      )}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
             <RunDataExplorer run={detail.data} />
@@ -96,11 +137,17 @@ export function Runs() {
             <RunArtifacts artifacts={detail.data.artifacts} />
           </>
         ) : (
-          <div className="empty-panel tall">No run selected.</div>
+          <EmptyState tall icon={Atom}>Select a run to view its details.</EmptyState>
         )}
       </section>
     </div>
   );
+}
+
+function phaseClass(status: string, current: boolean): string {
+  if (current) return "current";
+  if (status === "completed") return "done";
+  return "";
 }
 
 function iconForPhase(status: string, current: boolean) {

--- a/web/ui/src/pages/Viewer.tsx
+++ b/web/ui/src/pages/Viewer.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Box, Cuboid } from "lucide-react";
+import { ArrowLeft, Box, Cuboid } from "lucide-react";
 import { api } from "../api";
-import { ExpandableText } from "../components/ExpandableText";
+import { Truncate } from "../components/Truncate";
 import { ModelViewer } from "../components/ModelViewer";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+import { PanelError } from "../components/StateBlock";
 import { hasViewableGeometry } from "../geometryArtifacts";
 
 export function Viewer() {
@@ -32,19 +34,24 @@ export function Viewer() {
     enabled: Boolean(selected)
   });
   const selectedRun =
-    selected && run.data?.case_name === selected.caseName && run.data.run_id === selected.runId
-      ? run.data
-      : null;
-  const emptyMessage = runs.isLoading || (Boolean(selected) && run.isLoading)
-    ? "Loading geometry exports..."
-    : hasRequestedRun
-      ? "The selected run does not have a viewable glTF geometry export."
-      : "No runs with viewable glTF geometry exports are available. Run the render phase to create one.";
+    selected && run.data?.case_name === selected.caseName && run.data.run_id === selected.runId ? run.data : null;
+  const emptyMessage =
+    runs.isLoading || (Boolean(selected) && run.isLoading)
+      ? "Loading geometry exports…"
+      : hasRequestedRun
+        ? "The selected run does not have a viewable glTF geometry export."
+        : "No runs with viewable glTF geometry exports are available. Run the render phase to create one.";
 
   return (
     <div className="page">
       <header className="page-header">
         <div>
+          {hasRequestedRun && (
+            <Link className="back-link" to="/viewer">
+              <ArrowLeft aria-hidden="true" />
+              All 3D runs
+            </Link>
+          )}
           <p className="eyebrow">Geometry exports</p>
           <h1>3D viewer</h1>
         </div>
@@ -71,23 +78,29 @@ export function Viewer() {
           </select>
         </label>
       </header>
-      {selectedRun ? (
+      {runs.isError ? (
+        <PanelError error={runs.error} onRetry={() => runs.refetch()} tall />
+      ) : run.isError && hasRequestedRun ? (
+        <PanelError error={run.error} onRetry={() => run.refetch()} tall />
+      ) : selectedRun ? (
         <>
           <section className="viewer-meta">
             <div>
               <Cuboid aria-hidden="true" />
-              <ExpandableText className="viewer-case" lines={1}>
-                {selectedRun.case_name}
-              </ExpandableText>
-              <ExpandableText className="viewer-run" lines={1}>
-                {selectedRun.run_id}
-              </ExpandableText>
+              <Truncate className="viewer-case">{selectedRun.case_name}</Truncate>
+              <Truncate className="viewer-run">{selectedRun.run_id}</Truncate>
             </div>
             <Link className="secondary-action" to={`/runs/${selectedRun.case_name}/${selectedRun.run_id}`}>
               Open run
             </Link>
           </section>
-          <ModelViewer artifacts={selectedRun.artifacts} />
+          <ErrorBoundary
+            fallback={(error, reset) => (
+              <PanelError error={error} label="Could not render this geometry." onRetry={reset} tall />
+            )}
+          >
+            <ModelViewer artifacts={selectedRun.artifacts} />
+          </ErrorBoundary>
         </>
       ) : (
         <div className="empty-panel tall">

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1,23 +1,168 @@
+/* ============================================================================
+   Thorium MSR Lab — design system
+   Instrument-grade, data-forward, honest. Fully tokenized for light + dark.
+   ========================================================================== */
+
 :root {
-  --ink: #172126;
-  --muted: #5e6c73;
-  --line: #d6dedb;
-  --line-strong: #b9c8c2;
-  --paper: #fbfcfb;
+  /* Surfaces & ink */
+  --bg: #eaf0ee;
   --surface: #ffffff;
   --surface-soft: #f3f7f5;
-  --accent: #006d63;
-  --accent-strong: #004f48;
-  --accent-soft: #dfeeea;
-  --amber: #8a5a00;
-  --blue: #285f87;
-  --danger: #a33a2a;
+  --surface-raised: #ffffff;
+  --ink: #131d21;
+  --ink-soft: #2c3a41;
+  --muted: #56656d;
+
+  /* Lines */
+  --line: #d9e1de;
+  --line-strong: #c0ccc7;
+
+  /* Accent (single source of truth) */
+  --accent: #0f766e;
+  --accent-strong: #0b5952;
+  --accent-soft: #dcefeb;
+  --on-accent: #ffffff;
+
+  /* Status */
+  --ok: #12734b;
+  --ok-soft: #dff1e6;
+  --warn: #8a5a00;
+  --warn-soft: #fbeecd;
+  --danger: #a5382a;
+  --danger-soft: #fbe6e1;
+  --info: #2360a5;
+  --info-soft: #dfeaf7;
+  --neutral-soft: #e9eeef;
+
+  /* Code / dark inlays */
+  --code-bg: #1c262c;
+  --code-ink: #eef3f6;
+
+  /* Chart tokens (read by ECharts via theme.ts) */
+  --chart-axis: #64727b;
+  --chart-grid: #e2e8ec;
+  --chart-label: #2f3a41;
+  --chart-1: #0f766e;
+  --chart-2: #2360a5;
+  --chart-3: #a1660a;
+  --chart-4: #7c56c7;
+  --chart-5: #a5382a;
+  --chart-6: #3f8a5b;
+
+  /* Elevation & shape */
+  --shadow-1: 0 1px 2px rgba(19, 29, 33, 0.05), 0 1px 1px rgba(19, 29, 33, 0.03);
+  --shadow-2: 0 6px 20px -8px rgba(19, 29, 33, 0.22);
+  --radius: 8px;
+  --radius-sm: 6px;
+  --radius-lg: 12px;
+
+  --grid-line-a: rgba(15, 118, 110, 0.035);
+  --grid-line-b: rgba(35, 96, 165, 0.025);
+
+  color-scheme: light dark;
   color: var(--ink);
-  background: #eef3f1;
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Dark palette — applied when explicitly chosen, or via OS when set to system. */
+:root[data-theme="dark"] {
+  --bg: #0c1315;
+  --surface: #141d20;
+  --surface-soft: #182327;
+  --surface-raised: #1a2529;
+  --ink: #e9efec;
+  --ink-soft: #cbd6d3;
+  --muted: #93a3a6;
+
+  --line: #26332f;
+  --line-strong: #35443f;
+
+  --accent: #34b6a6;
+  --accent-strong: #57cdbe;
+  --accent-soft: rgba(52, 182, 166, 0.16);
+  --on-accent: #05221f;
+
+  --ok: #4cc186;
+  --ok-soft: rgba(76, 193, 134, 0.15);
+  --warn: #d3a24a;
+  --warn-soft: rgba(211, 162, 74, 0.16);
+  --danger: #e8846f;
+  --danger-soft: rgba(232, 132, 111, 0.16);
+  --info: #6aa9e6;
+  --info-soft: rgba(106, 169, 230, 0.16);
+  --neutral-soft: #223033;
+
+  --code-bg: #0a1113;
+  --code-ink: #dce6e3;
+
+  --chart-axis: #8496a0;
+  --chart-grid: #26332f;
+  --chart-label: #cbd6d3;
+  --chart-1: #34b6a6;
+  --chart-2: #6aa9e6;
+  --chart-3: #d3a24a;
+  --chart-4: #a98be0;
+  --chart-5: #e8846f;
+  --chart-6: #6bbd85;
+
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-2: 0 10px 26px -10px rgba(0, 0, 0, 0.6);
+
+  --grid-line-a: rgba(52, 182, 166, 0.05);
+  --grid-line-b: rgba(106, 169, 230, 0.035);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #0c1315;
+    --surface: #141d20;
+    --surface-soft: #182327;
+    --surface-raised: #1a2529;
+    --ink: #e9efec;
+    --ink-soft: #cbd6d3;
+    --muted: #93a3a6;
+
+    --line: #26332f;
+    --line-strong: #35443f;
+
+    --accent: #34b6a6;
+    --accent-strong: #57cdbe;
+    --accent-soft: rgba(52, 182, 166, 0.16);
+    --on-accent: #05221f;
+
+    --ok: #4cc186;
+    --ok-soft: rgba(76, 193, 134, 0.15);
+    --warn: #d3a24a;
+    --warn-soft: rgba(211, 162, 74, 0.16);
+    --danger: #e8846f;
+    --danger-soft: rgba(232, 132, 111, 0.16);
+    --info: #6aa9e6;
+    --info-soft: rgba(106, 169, 230, 0.16);
+    --neutral-soft: #223033;
+
+    --code-bg: #0a1113;
+    --code-ink: #dce6e3;
+
+    --chart-axis: #8496a0;
+    --chart-grid: #26332f;
+    --chart-label: #cbd6d3;
+    --chart-1: #34b6a6;
+    --chart-2: #6aa9e6;
+    --chart-3: #d3a24a;
+    --chart-4: #a98be0;
+    --chart-5: #e8846f;
+    --chart-6: #6bbd85;
+
+    --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-2: 0 10px 26px -10px rgba(0, 0, 0, 0.6);
+
+    --grid-line-a: rgba(52, 182, 166, 0.05);
+    --grid-line-b: rgba(106, 169, 230, 0.035);
+  }
 }
 
 * {
@@ -33,10 +178,11 @@ body {
   min-width: 320px;
   min-height: 100vh;
   overflow-x: hidden;
+  color: var(--ink);
   background:
-    linear-gradient(90deg, rgba(0, 109, 99, 0.035) 1px, transparent 1px),
-    linear-gradient(0deg, rgba(40, 95, 135, 0.025) 1px, transparent 1px),
-    #eef3f1;
+    linear-gradient(90deg, var(--grid-line-a) 1px, transparent 1px),
+    linear-gradient(0deg, var(--grid-line-b) 1px, transparent 1px),
+    var(--bg);
   background-size: 36px 36px;
 }
 
@@ -54,6 +200,7 @@ button,
 input,
 select {
   font: inherit;
+  color: inherit;
   max-width: 100%;
 }
 
@@ -63,8 +210,38 @@ canvas {
 }
 
 :focus-visible {
-  outline: 2px solid var(--blue);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --- Truncation utilities ------------------------------------------------ */
+
+.truncate {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.truncate[style*="--clamp-lines"] {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--clamp-lines, 1);
+  white-space: normal;
 }
 
 .expandable-text {
@@ -73,6 +250,9 @@ canvas {
   min-width: 0;
   max-width: 100%;
   color: inherit;
+}
+
+.expandable-text.interactive {
   cursor: zoom-in;
 }
 
@@ -86,7 +266,7 @@ canvas {
   -webkit-line-clamp: var(--line-count);
 }
 
-.expandable-text.expanded {
+.expandable-text.expanded.interactive {
   cursor: zoom-out;
 }
 
@@ -98,9 +278,11 @@ canvas {
   -webkit-line-clamp: unset;
 }
 
+/* --- App shell ----------------------------------------------------------- */
+
 .app-shell {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr);
+  grid-template-columns: 248px minmax(0, 1fr);
   min-height: 100vh;
   max-width: 100vw;
   overflow-x: hidden;
@@ -111,11 +293,12 @@ canvas {
   top: 0;
   height: 100vh;
   padding: 18px 14px;
-  background: rgba(251, 252, 251, 0.96);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(6px);
   border-right: 1px solid var(--line);
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 18px;
   min-width: 0;
 }
 
@@ -123,7 +306,7 @@ canvas {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 8px 18px;
+  padding: 6px 8px 16px;
   border-bottom: 1px solid var(--line);
 }
 
@@ -133,6 +316,8 @@ canvas {
 
 .brand svg {
   color: var(--accent);
+  width: 26px;
+  height: 26px;
 }
 
 .menu-toggle {
@@ -141,9 +326,9 @@ canvas {
   height: 40px;
   margin-left: auto;
   border: 1px solid var(--line-strong);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
-  color: #2d3946;
+  color: var(--ink-soft);
   align-items: center;
   justify-content: center;
   cursor: pointer;
@@ -163,14 +348,19 @@ canvas {
   white-space: nowrap;
 }
 
+.brand strong {
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+
 .brand span {
   color: var(--muted);
-  font-size: 13px;
+  font-size: 12.5px;
 }
 
 .nav-list {
   display: grid;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
   max-width: 100%;
 }
@@ -178,12 +368,13 @@ canvas {
 .nav-list a {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 11px;
   min-height: 42px;
   padding: 0 10px 0 12px;
   border-left: 3px solid transparent;
-  border-radius: 4px;
-  color: #415058;
+  border-radius: var(--radius-sm);
+  color: var(--ink-soft);
+  transition: background 0.14s ease, color 0.14s ease;
 }
 
 .nav-list a span {
@@ -191,13 +382,22 @@ canvas {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 600;
 }
 
-.nav-list a.active,
 .nav-list a:hover {
+  background: var(--surface-soft);
+  color: var(--ink);
+}
+
+.nav-list a.active {
   background: var(--accent-soft);
   border-left-color: var(--accent);
   color: var(--accent-strong);
+}
+
+.nav-list a.active span {
+  font-weight: 700;
 }
 
 .nav-list svg,
@@ -211,22 +411,102 @@ canvas {
   flex: 0 0 auto;
 }
 
-.sidebar-note {
+/* Account block (replaces the old dual-purpose note). */
+.account-block {
   margin-top: auto;
-  padding: 12px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: var(--paper);
-  display: flex;
+  display: grid;
   gap: 10px;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.4;
-  min-width: 0;
 }
 
-.sidebar-note .expandable-text {
-  flex: 1 1 auto;
+.account-card {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 2px 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.account-card > svg {
+  grid-row: 1 / span 2;
+  width: 20px;
+  height: 20px;
+  color: var(--accent);
+}
+
+.account-label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.account-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 650;
+  font-size: 13px;
+}
+
+.account-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  align-self: start;
+  margin-top: 2px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-soft);
+}
+
+.theme-toggle button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  flex: 1 1 0;
+  min-height: 30px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+
+.theme-toggle button svg {
+  width: 15px;
+  height: 15px;
+}
+
+.theme-toggle button:hover {
+  color: var(--ink);
+}
+
+.theme-toggle button.active {
+  background: var(--surface);
+  color: var(--accent-strong);
+  box-shadow: var(--shadow-1);
 }
 
 .main-panel {
@@ -234,16 +514,19 @@ canvas {
   overflow-x: hidden;
 }
 
+/* --- Page scaffolding ---------------------------------------------------- */
+
 .page {
-  padding: 30px 32px;
+  padding: 28px 30px;
+  max-width: 1440px;
 }
 
 .page-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 20px;
-  margin-bottom: 24px;
+  margin-bottom: 22px;
 }
 
 .page-header > div {
@@ -257,55 +540,108 @@ canvas {
 .page-header h1,
 .hero-copy h2 {
   margin: 0;
-  font-size: 28px;
-  line-height: 1.12;
-  letter-spacing: 0;
-  font-weight: 760;
+  font-size: 27px;
+  line-height: 1.14;
+  letter-spacing: -0.02em;
+  font-weight: 750;
 }
 
 .page-header.compact h1 {
-  font-size: 24px;
+  font-size: 23px;
 }
 
 .eyebrow {
   margin: 0 0 6px;
-  color: var(--amber);
+  color: var(--accent-strong);
   font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 700;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.back-link svg {
+  width: 15px;
+  height: 15px;
+}
+
+.back-link:hover {
+  color: var(--accent-strong);
+}
+
+/* --- Buttons ------------------------------------------------------------- */
 
 .primary-action,
 .secondary-action {
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
   min-height: 40px;
-  padding: 0 14px;
-  font-weight: 700;
+  padding: 0 15px;
+  font-weight: 650;
   cursor: pointer;
   max-width: 100%;
   min-width: 0;
+  transition: background 0.14s ease, border-color 0.14s ease, transform 0.06s ease, box-shadow 0.14s ease;
 }
 
 .primary-action {
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
+  box-shadow: var(--shadow-1);
 }
 
 .primary-action:hover {
   background: var(--accent-strong);
 }
 
+.primary-action:active,
+.secondary-action:active {
+  transform: translateY(1px);
+}
+
 .secondary-action {
   background: var(--surface);
   border: 1px solid var(--line-strong);
-  color: #2d3946;
+  color: var(--ink-soft);
+}
+
+.secondary-action:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+  background: var(--surface-soft);
+}
+
+.primary-action:disabled,
+.secondary-action:disabled,
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.primary-action:disabled:hover {
+  background: var(--accent);
+}
+
+.secondary-action:disabled:hover {
+  border-color: var(--line-strong);
+  color: var(--ink-soft);
+  background: var(--surface);
 }
 
 .primary-action span,
@@ -320,30 +656,33 @@ canvas {
   width: 100%;
 }
 
+/* --- Hero ---------------------------------------------------------------- */
+
 .hero-band {
   display: grid;
-  grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1.1fr);
+  grid-template-columns: minmax(280px, 0.92fr) minmax(320px, 1.08fr);
   gap: 24px;
   align-items: stretch;
-  min-height: 316px;
+  min-height: 300px;
   padding: 22px;
-  background: var(--paper);
+  background: var(--surface);
   border: 1px solid var(--line);
   border-left: 4px solid var(--accent);
-  border-radius: 6px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
 }
 
 .hero-copy {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 28px;
+  gap: 26px;
   min-width: 0;
 }
 
 .hero-media {
-  min-height: 288px;
-  border-radius: 6px;
+  min-height: 268px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
   background: var(--surface-soft);
   border: 1px solid var(--line);
@@ -358,57 +697,32 @@ canvas {
   display: block;
 }
 
+/* Honest reactor readout (no fabricated bars). */
 .reactor-readout {
   display: grid;
-  grid-template-columns: 1fr 190px;
-  gap: 18px;
+  grid-template-rows: auto 1fr;
+  gap: 16px;
   height: 100%;
-  min-height: 288px;
+  min-height: 268px;
   padding: 18px;
   background: var(--surface);
 }
 
-.readout-grid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  align-items: end;
-  gap: 10px;
-  min-height: 210px;
-  padding: 18px;
-  border: 1px solid var(--line);
-  background:
-    repeating-linear-gradient(0deg, transparent 0 31px, rgba(0, 109, 99, 0.12) 32px),
-    var(--paper);
+.readout-caption {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-.readout-grid span {
-  display: block;
-  border: 1px solid rgba(0, 109, 99, 0.5);
-  background: rgba(0, 109, 99, 0.14);
-}
-
-.readout-grid span:nth-child(1) {
-  height: 38%;
-}
-
-.readout-grid span:nth-child(2) {
-  height: 64%;
-}
-
-.readout-grid span:nth-child(3) {
-  height: 50%;
-}
-
-.readout-grid span:nth-child(4) {
-  height: 78%;
-}
-
-.readout-grid span:nth-child(5) {
-  height: 44%;
-}
-
-.readout-grid span:nth-child(6) {
-  height: 70%;
+.readout-caption svg {
+  width: 16px;
+  height: 16px;
+  color: var(--accent);
 }
 
 .readout-table {
@@ -422,7 +736,7 @@ canvas {
   grid-template-columns: 1fr auto;
   align-items: center;
   gap: 10px;
-  min-height: 52px;
+  min-height: 50px;
   border-bottom: 1px solid var(--line);
 }
 
@@ -431,11 +745,65 @@ canvas {
   font-size: 12px;
   font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .readout-table strong {
   font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
   font-size: 18px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Real run-status distribution bar (Dashboard). */
+.status-strip {
+  display: grid;
+  gap: 8px;
+}
+
+.status-strip-bar {
+  display: flex;
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--neutral-soft);
+}
+
+.status-strip-bar .seg {
+  height: 100%;
+}
+
+.status-strip-bar .seg.tone-ok {
+  background: var(--ok);
+}
+.status-strip-bar .seg.tone-danger {
+  background: var(--danger);
+}
+.status-strip-bar .seg.tone-info {
+  background: var(--info);
+}
+.status-strip-bar .seg.tone-neutral {
+  background: var(--line-strong);
+}
+
+.status-strip-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+}
+
+.status-strip-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-strip-legend i {
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
 }
 
 .stat-row {
@@ -451,7 +819,7 @@ canvas {
   gap: 8px;
   padding: 12px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
 }
 
@@ -465,24 +833,33 @@ canvas {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 13px;
+  font-weight: 550;
 }
+
+.stat-item strong {
+  font-variant-numeric: tabular-nums;
+  font-size: 18px;
+}
+
+/* --- Grids & panels ------------------------------------------------------ */
 
 .dashboard-grid,
 .two-column {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
-  margin-top: 18px;
+  gap: 16px;
+  margin-top: 16px;
 }
 
 .panel,
 .artifact-pane {
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 16px;
   min-width: 0;
-  box-shadow: 0 1px 2px rgba(23, 33, 38, 0.04);
+  box-shadow: var(--shadow-1);
 }
 
 .panel h2,
@@ -491,8 +868,8 @@ canvas {
 .parameter-band h2,
 .parameter-band h3 {
   margin: 0 0 12px;
-  font-size: 17px;
-  letter-spacing: 0;
+  font-size: 16px;
+  letter-spacing: -0.01em;
 }
 
 .section-title,
@@ -510,50 +887,154 @@ canvas {
   min-width: 0;
 }
 
+.pane-title {
+  color: var(--ink-soft);
+  font-weight: 700;
+  font-size: 13.5px;
+}
+
 .section-title svg,
 .pane-title svg {
   color: var(--accent);
-}
-
-.run-line {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 6px 10px;
-  margin-bottom: 14px;
-  min-width: 0;
-}
-
-.run-title {
-  font-weight: 750;
-}
-
-.run-meta {
-  grid-column: 1 / -1;
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.run-line mark {
-  justify-self: start;
+  flex: 0 0 auto;
 }
 
 mark,
 .tag-row > span {
-  padding: 4px 8px;
+  padding: 3px 9px;
   border-radius: 999px;
-  background: #fff4d6;
-  color: #775000;
+  background: var(--neutral-soft);
+  color: var(--ink-soft);
+  font-size: 12px;
+  font-weight: 650;
+  max-width: 100%;
+}
+
+/* --- Status badge -------------------------------------------------------- */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px 3px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+  max-width: 100%;
+  border: 1px solid transparent;
+}
+
+.status-badge .status-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: currentColor;
+}
+
+.status-badge.tone-ok {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
+.status-badge.tone-info {
+  background: var(--info-soft);
+  color: var(--info);
+}
+.status-badge.tone-warn {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.status-badge.tone-danger {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+.status-badge.tone-neutral {
+  background: var(--neutral-soft);
+  color: var(--muted);
+}
+
+.status-badge.tone-info .status-dot {
+  animation: pulse-dot 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* --- Progress bar -------------------------------------------------------- */
+
+.progress-bar {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--neutral-soft);
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.4s ease;
+}
+
+.progress-bar.indeterminate .progress-fill {
+  width: 40%;
+  animation: progress-slide 1.3s ease-in-out infinite;
+}
+
+@keyframes progress-slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(320%);
+  }
+}
+
+.progress-line {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.progress-percent {
+  font-variant-numeric: tabular-nums;
   font-size: 12px;
   font-weight: 700;
-  max-width: 100%;
+  color: var(--accent-strong);
 }
 
 .text-link {
   display: inline-flex;
+  align-items: center;
+  gap: 5px;
   margin-top: 10px;
-  color: var(--accent);
-  font-weight: 700;
+  color: var(--accent-strong);
+  font-weight: 650;
+}
+
+.text-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .chart {
@@ -561,12 +1042,14 @@ mark,
   min-width: 0;
 }
 
+/* --- Lists --------------------------------------------------------------- */
+
 .doc-links,
 .case-list,
 .run-list,
 .file-list {
   display: grid;
-  gap: 8px;
+  gap: 7px;
 }
 
 .doc-links a,
@@ -580,12 +1063,13 @@ mark,
   text-align: left;
   border: 1px solid var(--line);
   border-left: 3px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
-  color: #26313d;
-  padding: 12px;
+  color: var(--ink-soft);
+  padding: 11px 12px;
   cursor: pointer;
   overflow: hidden;
+  transition: background 0.14s ease, border-color 0.14s ease, transform 0.06s ease;
 }
 
 .doc-links a {
@@ -604,8 +1088,10 @@ mark,
   grid-column: 2;
   grid-row: 1 / span 2;
   justify-self: end;
+  color: var(--muted);
 }
 
+.run-list button .status-badge,
 .run-list button mark {
   grid-column: 2;
   grid-row: 1;
@@ -618,17 +1104,19 @@ mark,
 }
 
 .list-title {
-  color: #26313d;
-  font-weight: 750;
+  color: var(--ink);
+  font-weight: 650;
 }
 
-.list-title:not(.expandable-text),
-.list-meta:not(.expandable-text) {
+.list-title:not(.expandable-text):not(.truncate),
+.list-meta:not(.expandable-text):not(.truncate) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.case-list button.selected .truncate,
+.run-list button.selected .truncate,
 .case-list button.selected .expandable-text > span,
 .run-list button.selected .expandable-text > span,
 .doc-links a.selected .list-title,
@@ -641,23 +1129,35 @@ mark,
 }
 
 .doc-links a:hover,
-.doc-links a.selected,
 .case-list button:hover,
+.run-list button:hover {
+  border-color: var(--line-strong);
+  background: var(--surface-soft);
+}
+
+.doc-links a:active,
+.case-list button:active,
+.run-list button:active {
+  transform: translateY(1px);
+}
+
+.doc-links a.selected,
 .case-list button.selected,
-.run-list button:hover,
 .run-list button.selected {
-  border-color: #0f766e;
+  border-color: var(--accent);
   border-left-color: var(--accent);
-  background: #eef7f4;
+  background: var(--accent-soft);
 }
 
 .doc-links small,
 .list-meta,
 .file-list small,
 .field small {
-  color: #667586;
+  color: var(--muted);
   font-size: 12px;
 }
+
+/* --- Science / docs index ------------------------------------------------ */
 
 .science-page {
   grid-template-columns: minmax(290px, 320px) minmax(0, 1fr);
@@ -676,7 +1176,7 @@ mark,
 
 .science-index .doc-links a {
   grid-template-columns: 1fr;
-  gap: 6px;
+  gap: 5px;
 }
 
 .science-index .doc-links small {
@@ -699,12 +1199,14 @@ mark,
 .science-meta span {
   border: 1px solid var(--line);
   border-radius: 999px;
-  background: var(--paper);
+  background: var(--surface-soft);
   color: var(--muted);
   font-size: 12px;
-  font-weight: 700;
-  padding: 4px 9px;
+  font-weight: 650;
+  padding: 3px 10px;
 }
+
+/* --- Split layout -------------------------------------------------------- */
 
 .split-page {
   display: grid;
@@ -741,23 +1243,25 @@ mark,
   min-width: 0;
   min-height: 74px;
   padding: 12px;
-  border: 1px solid #dce5e1;
-  border-radius: 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   background: var(--surface);
 }
 
 .simulation-overview dt {
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 11.5px;
+  font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .simulation-overview dd {
   margin: 6px 0 0;
   font-size: 18px;
-  font-weight: 800;
+  font-weight: 750;
   min-width: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 .output-focus {
@@ -790,6 +1294,11 @@ mark,
   font-size: 18px;
 }
 
+.run-meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .output-section-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -801,9 +1310,9 @@ mark,
   min-width: 0;
   padding: 16px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--surface);
-  box-shadow: 0 1px 2px rgba(23, 33, 38, 0.04);
+  box-shadow: var(--shadow-1);
 }
 
 .output-section-header {
@@ -831,12 +1340,14 @@ mark,
 
 .output-section-header h2 {
   min-width: 0;
+  font-size: 15px;
 }
 
 .output-summary {
-  margin: 0 0 12px;
+  margin: 10px 0 12px;
   color: var(--muted);
-  line-height: 1.45;
+  line-height: 1.5;
+  font-size: 13.5px;
 }
 
 .output-metric-grid {
@@ -847,17 +1358,17 @@ mark,
 
 .output-metric {
   min-width: 0;
-  min-height: 76px;
+  min-height: 74px;
   padding: 10px;
-  border: 1px solid #e0e7ee;
-  border-radius: 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   background: var(--surface-soft);
 }
 
 .output-metric dt {
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 11.5px;
+  font-weight: 700;
 }
 
 .output-metric dd {
@@ -866,10 +1377,11 @@ mark,
 }
 
 .output-metric-value {
-  color: #21303a;
+  color: var(--ink);
   font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-  font-size: 17px;
-  font-weight: 800;
+  font-size: 16px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .output-notes {
@@ -904,7 +1416,7 @@ mark,
 .parameter-band {
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 16px;
 }
 
@@ -917,12 +1429,13 @@ mark,
 .parameter-table div {
   min-height: 74px;
   padding: 10px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-soft);
-  border: 1px solid #e0e7ee;
+  border: 1px solid var(--line);
 }
 
 .parameter-table .expandable-text,
+.parameter-table .truncate,
 .fact-list dt,
 .fact-list dd {
   display: block;
@@ -930,24 +1443,27 @@ mark,
 
 .parameter-value {
   margin: 4px 0;
-  font-weight: 750;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .parameter-label,
 .field-title {
-  color: #2e3945;
-  font-weight: 700;
+  color: var(--ink-soft);
+  font-weight: 650;
 }
 
 .parameter-meta,
 .field-hint {
-  color: #667586;
+  color: var(--muted);
   font-size: 12px;
 }
 
+/* --- Builder ------------------------------------------------------------- */
+
 .builder-layout {
   display: grid;
-  grid-template-columns: 320px minmax(0, 1fr);
+  grid-template-columns: 340px minmax(0, 1fr);
   gap: 20px;
   align-items: start;
 }
@@ -957,10 +1473,11 @@ mark,
   top: 20px;
   display: grid;
   gap: 14px;
-  background: #ffffff;
+  background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 16px;
+  box-shadow: var(--shadow-1);
 }
 
 .field {
@@ -977,19 +1494,64 @@ mark,
 .field > .field-title,
 .check-line > span,
 .check-tile > span {
-  font-weight: 700;
-  color: #2e3945;
+  font-weight: 650;
+  color: var(--ink-soft);
 }
 
 .field input,
 .field select {
   width: 100%;
   min-height: 38px;
-  border: 1px solid #cbd5df;
-  border-radius: 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
   background: var(--surface);
-  color: #1f2934;
+  color: var(--ink);
   padding: 0 10px;
+  transition: border-color 0.14s ease, box-shadow 0.14s ease;
+}
+
+.field input:focus-visible,
+.field select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.field input:disabled,
+.field select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: var(--surface-soft);
+}
+
+.control-group {
+  display: grid;
+  gap: 10px;
+  transition: opacity 0.14s ease;
+}
+
+.control-group.is-inactive {
+  opacity: 0.55;
+}
+
+.builder-section-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 11.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.inactive-hint {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .phase-grid {
@@ -1004,13 +1566,32 @@ mark,
   align-items: center;
   gap: 8px;
   min-height: 38px;
+  cursor: pointer;
 }
 
 .check-tile {
-  border: 1px solid #d8e0e7;
-  border-radius: 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
   padding: 0 10px;
   background: var(--surface-soft);
+  transition: border-color 0.14s ease, background 0.14s ease;
+}
+
+.check-tile:hover {
+  border-color: var(--accent);
+}
+
+.check-tile:has(input:checked) {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.check-tile input,
+.check-line input {
+  accent-color: var(--accent);
+  width: 16px;
+  height: 16px;
 }
 
 .builder-options,
@@ -1029,17 +1610,122 @@ mark,
   align-items: center;
   gap: 8px;
   padding: 12px;
-  border: 1px solid #cfe2db;
-  border-radius: 6px;
-  background: #edf8f2;
-  color: #145d45;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-soft);
+  color: var(--ink-soft);
   min-width: 0;
 }
 
-.draft-note .expandable-text,
-.event-banner .expandable-text {
-  flex: 1 1 auto;
+.draft-note svg,
+.event-banner svg {
+  color: var(--accent);
 }
+
+.draft-note .expandable-text,
+.event-banner .expandable-text,
+.event-banner .event-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.event-body {
+  display: grid;
+  gap: 8px;
+}
+
+.quota-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--surface-soft);
+  color: var(--ink-soft);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.quota-note svg {
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+
+.quota-note.blocked {
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--line));
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.quota-note.blocked svg {
+  color: var(--danger);
+}
+
+.quota-count {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Validation result panel (Builder "Check inputs"). */
+.validation-result {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  font-size: 13px;
+  min-width: 0;
+}
+
+.validation-result svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.validation-result.valid {
+  background: var(--ok-soft);
+  border-color: color-mix(in srgb, var(--ok) 32%, var(--line));
+  color: var(--ok);
+}
+
+.validation-result.invalid {
+  background: var(--danger-soft);
+  border-color: color-mix(in srgb, var(--danger) 32%, var(--line));
+  color: var(--danger);
+}
+
+.validation-result .validation-body {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.validation-result strong {
+  font-weight: 700;
+}
+
+.validation-result details {
+  margin-top: 4px;
+}
+
+.validation-result summary {
+  cursor: pointer;
+  font-weight: 650;
+  color: inherit;
+}
+
+.validation-result .text-preview {
+  margin-top: 8px;
+  max-height: 260px;
+}
+
+.builder-actions {
+  display: grid;
+  gap: 8px;
+}
+
+/* --- Run data explorer --------------------------------------------------- */
 
 .run-data-stack {
   display: grid;
@@ -1062,7 +1748,7 @@ mark,
   min-height: 74px;
   padding: 12px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
 }
 
@@ -1076,17 +1762,19 @@ mark,
 .run-kpi span {
   min-width: 0;
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 800;
+  font-size: 11.5px;
+  font-weight: 700;
   overflow: hidden;
   text-overflow: ellipsis;
   text-transform: uppercase;
+  letter-spacing: 0.02em;
   white-space: nowrap;
 }
 
 .run-kpi strong {
   font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-  font-size: 21px;
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
 }
 
 .run-chart-grid {
@@ -1133,18 +1821,19 @@ mark,
   padding: 9px 10px;
   border: 1px solid var(--line);
   border-left: 3px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-soft);
-  color: #26313d;
+  color: var(--ink-soft);
   text-align: left;
   cursor: pointer;
+  transition: background 0.14s ease, border-color 0.14s ease;
 }
 
 .data-artifact-list button.selected,
 .data-artifact-list button:hover {
-  border-color: #0f766e;
+  border-color: var(--accent);
   border-left-color: var(--accent);
-  background: #eef7f4;
+  background: var(--accent-soft);
 }
 
 .data-artifact-list button svg {
@@ -1163,7 +1852,7 @@ mark,
 }
 
 .data-artifact-list button span {
-  font-weight: 750;
+  font-weight: 650;
 }
 
 .data-artifact-list button small {
@@ -1211,7 +1900,7 @@ mark,
   max-height: 560px;
   overflow: auto;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
 }
 
 .data-table {
@@ -1220,13 +1909,14 @@ mark,
   border-collapse: collapse;
   background: var(--surface);
   font-size: 13px;
+  font-variant-numeric: tabular-nums;
 }
 
 .data-table th,
 .data-table td {
   max-width: 360px;
   padding: 8px 10px;
-  border-bottom: 1px solid #e3ebe8;
+  border-bottom: 1px solid var(--line);
   text-align: left;
   vertical-align: top;
 }
@@ -1235,11 +1925,12 @@ mark,
   position: sticky;
   top: 0;
   z-index: 1;
-  background: #e8f1ef;
-  color: #415058;
-  font-size: 12px;
-  font-weight: 800;
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 11.5px;
+  font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .data-table td {
@@ -1247,7 +1938,7 @@ mark,
 }
 
 .data-table td:first-child {
-  color: #334149;
+  color: var(--ink-soft);
   font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
   font-size: 12px;
 }
@@ -1264,20 +1955,143 @@ mark,
   margin: 0;
   overflow: auto;
   border: 1px solid var(--line);
-  border-radius: 6px;
-  background: #1f2934;
-  color: #f7f9fb;
+  border-radius: var(--radius-sm);
+  background: var(--code-bg);
+  color: var(--code-ink);
   padding: 12px;
   white-space: pre-wrap;
+  font-size: 12.5px;
 }
+
+/* --- State blocks (loading / error / empty) & error box ------------------ */
 
 .error-box {
   padding: 12px;
-  border-radius: 6px;
-  background: #fff0ee;
-  border: 1px solid #f0b7ad;
-  color: #972514;
+  border-radius: var(--radius-sm);
+  background: var(--danger-soft);
+  border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--line));
+  color: var(--danger);
+  font-size: 13px;
 }
+
+.state-block {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 120px;
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--surface-soft);
+  color: var(--muted);
+}
+
+.state-block.tall {
+  min-height: 300px;
+  justify-content: center;
+  text-align: center;
+}
+
+.state-block.empty {
+  border-style: dashed;
+  justify-content: center;
+  text-align: center;
+}
+
+.state-block.empty svg {
+  width: 18px;
+  height: 18px;
+  opacity: 0.7;
+}
+
+.state-block.error {
+  border-color: color-mix(in srgb, var(--danger) 30%, var(--line));
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.state-block.error > svg {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+}
+
+.state-block.error > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.state-block .state-detail {
+  color: inherit;
+  opacity: 0.85;
+  font-size: 12.5px;
+  overflow-wrap: anywhere;
+}
+
+.state-block.loading {
+  display: block;
+}
+
+.skeleton-lines {
+  display: grid;
+  gap: 10px;
+  width: 100%;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--neutral-soft) 25%, color-mix(in srgb, var(--neutral-soft) 55%, var(--surface)) 50%, var(--neutral-soft) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.3s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Legacy empty panel kept for existing call sites. */
+.empty-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  background: var(--surface-soft);
+  text-align: center;
+  padding: 12px;
+}
+
+.empty-panel.tall {
+  min-height: 320px;
+  gap: 10px;
+  flex-direction: column;
+}
+
+.empty-panel.tall svg {
+  width: 22px;
+  height: 22px;
+  opacity: 0.7;
+}
+
+.route-loading {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+
+/* --- Admin --------------------------------------------------------------- */
 
 .admin-panel {
   margin-top: 18px;
@@ -1295,9 +2109,10 @@ mark,
   align-items: center;
   padding: 10px 12px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-soft);
   min-width: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 .admin-row > * {
@@ -1305,12 +2120,41 @@ mark,
 }
 
 .admin-row.header {
-  background: #e8f1ef;
-  color: #415058;
-  font-size: 12px;
-  font-weight: 800;
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 11.5px;
+  font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
+
+.fact-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.fact-list div {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  background: var(--surface-soft);
+}
+
+.fact-list dt {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.fact-list dd {
+  margin: 4px 0 0;
+  font-weight: 650;
+  min-width: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Run timeline -------------------------------------------------------- */
 
 .timeline {
   display: flex;
@@ -1324,42 +2168,36 @@ mark,
   align-items: center;
   gap: 6px;
   min-height: 34px;
-  padding: 0 10px;
-  border: 1px solid #d8e0e7;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
   border-radius: 999px;
-  background: #ffffff;
-  color: #536170;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.timeline div svg {
+  width: 15px;
+  height: 15px;
 }
 
 .timeline div.current {
-  border-color: #0f766e;
-  color: #0c5f59;
-  background: #e7f5f2;
+  border-color: var(--accent);
+  color: var(--accent-strong);
+  background: var(--accent-soft);
 }
 
-.fact-list {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  margin: 0;
+.timeline div.done {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 32%, var(--line));
 }
 
-.fact-list div {
-  border: 1px solid #e0e7ee;
-  border-radius: 6px;
-  padding: 10px;
+.timeline div.done svg {
+  color: var(--ok);
 }
 
-.fact-list dt {
-  color: #667586;
-  font-size: 12px;
-}
-
-.fact-list dd {
-  margin: 4px 0 0;
-  font-weight: 700;
-  min-width: 0;
-}
+/* --- Artifacts ----------------------------------------------------------- */
 
 .artifact-grid {
   grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr);
@@ -1393,10 +2231,19 @@ mark,
   align-items: center;
   justify-content: center;
   aspect-ratio: 4 / 3;
-  border: 1px solid #d8e0e7;
-  border-radius: 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  background: #f7f9fb;
+  background: var(--surface-soft);
+  transition: border-color 0.14s ease, transform 0.06s ease;
+}
+
+.media-tile:hover {
+  border-color: var(--accent);
+}
+
+.media-tile:active {
+  transform: translateY(1px);
 }
 
 .media-tile small {
@@ -1405,12 +2252,12 @@ mark,
   bottom: 6px;
   left: 6px;
   padding: 4px 6px;
-  border: 1px solid rgba(214, 222, 219, 0.9);
+  border: 1px solid var(--line);
   border-radius: 4px;
-  background: rgba(255, 255, 255, 0.92);
-  color: #334149;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  color: var(--ink-soft);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 650;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1421,21 +2268,33 @@ mark,
   cursor: default;
 }
 
+.file-list .file-item svg:first-child {
+  color: var(--accent);
+}
+
 .icon-action {
   width: 34px;
   height: 34px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--accent);
+  transition: border-color 0.14s ease, background 0.14s ease;
+}
+
+.icon-action:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
 }
 
 .icon-action svg {
   width: 16px;
   height: 16px;
 }
+
+/* --- Docs body ----------------------------------------------------------- */
 
 .docs-layout {
   display: grid;
@@ -1450,68 +2309,79 @@ mark,
   max-width: 100%;
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 24px 28px;
   line-height: 1.68;
   overflow-wrap: break-word;
-  box-shadow: 0 1px 2px rgba(23, 33, 38, 0.04);
+  box-shadow: var(--shadow-1);
 }
 
 .artifact-pane .markdown-body {
   max-height: 680px;
   overflow: auto;
+  box-shadow: none;
 }
 
 .markdown-body h1,
 .markdown-body h2,
 .markdown-body h3 {
-  letter-spacing: 0;
-  line-height: 1.18;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  scroll-margin-top: 20px;
 }
 
 .markdown-body h1 {
-  font-size: 32px;
+  font-size: 30px;
   margin-top: 0;
 }
 
 .markdown-body h2 {
-  margin-top: 34px;
+  margin-top: 32px;
   padding-top: 8px;
   border-top: 1px solid var(--line);
-  font-size: 22px;
+  font-size: 21px;
 }
 
 .markdown-body h3 {
-  font-size: 18px;
+  font-size: 17px;
 }
 
 .markdown-body p,
 .markdown-body li {
-  color: #243039;
+  color: var(--ink-soft);
 }
 
 .markdown-body a {
-  color: var(--blue);
-  font-weight: 650;
+  color: var(--accent-strong);
+  font-weight: 600;
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
 
 .markdown-body code {
-  background: #edf2f0;
+  background: var(--surface-soft);
+  border: 1px solid var(--line);
   border-radius: 4px;
-  padding: 2px 4px;
+  padding: 1px 5px;
+  font-size: 0.88em;
   overflow-wrap: anywhere;
 }
 
 .markdown-body pre {
   max-width: 100%;
   overflow: auto;
-  background: #1f2934;
-  color: #f7f9fb;
-  border-radius: 6px;
-  padding: 12px;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  border-radius: var(--radius-sm);
+  padding: 14px;
+}
+
+.markdown-body pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
 }
 
 .markdown-body .katex-display {
@@ -1522,7 +2392,7 @@ mark,
   padding: 14px 16px;
   border: 1px solid var(--line);
   border-left: 4px solid var(--accent);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--surface-soft);
 }
 
@@ -1542,58 +2412,53 @@ mark,
   display: block;
   max-width: 100%;
   overflow-x: auto;
+  border-collapse: collapse;
 }
 
-.toc,
-.formula-stack {
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid var(--line);
+  padding: 7px 10px;
+}
+
+.markdown-body th {
+  background: var(--surface-soft);
+}
+
+.toc {
   display: grid;
-  gap: 8px;
+  gap: 2px;
   background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 14px;
-  box-shadow: 0 1px 2px rgba(23, 33, 38, 0.04);
+  box-shadow: var(--shadow-1);
 }
 
-.toc > span,
-.toc .toc-item {
+.toc .section-title {
+  margin-bottom: 8px;
+}
+
+.toc a.toc-item {
+  display: block;
+  padding: 6px 8px;
+  border-left: 2px solid transparent;
+  border-radius: 4px;
   color: var(--muted);
   font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: background 0.14s ease, color 0.14s ease;
 }
 
-.formula-card {
-  display: grid;
-  gap: 6px;
-  padding: 10px 0;
-  border-top: 1px solid var(--line);
+.toc a.toc-item:hover {
+  background: var(--surface-soft);
+  color: var(--ink);
+  border-left-color: var(--accent);
 }
 
-.formula-card:first-of-type {
-  border-top: 0;
-}
-
-.formula-card > span {
-  color: #334149;
-  font-size: 12px;
-  font-weight: 750;
-  text-transform: uppercase;
-}
-
-.formula-math {
-  min-width: 0;
-  overflow-x: auto;
-}
-
-.formula-math p {
-  margin: 0;
-}
-
-.formula-math .katex-display {
-  margin: 0;
-  padding: 8px 0;
-  overflow-x: auto;
-  text-align: left;
-}
+/* --- 3D viewer ----------------------------------------------------------- */
 
 .viewer-meta {
   display: flex;
@@ -1601,11 +2466,12 @@ mark,
   justify-content: space-between;
   gap: 14px;
   margin-bottom: 14px;
-  background: #ffffff;
+  background: var(--surface);
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 12px 14px;
   min-width: 0;
+  box-shadow: var(--shadow-1);
 }
 
 .viewer-meta div {
@@ -1615,8 +2481,12 @@ mark,
   min-width: 0;
 }
 
+.viewer-meta div svg {
+  color: var(--accent);
+}
+
 .viewer-case {
-  font-weight: 750;
+  font-weight: 650;
 }
 
 .viewer-run {
@@ -1629,10 +2499,10 @@ mark,
   position: relative;
   height: min(72vh, 760px);
   min-height: 460px;
-  border: 1px solid #d8e0e7;
-  border-radius: 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
   overflow: hidden;
-  background: #f6f8fa;
+  background: var(--surface-soft);
 }
 
 .viewer-toolbar {
@@ -1648,13 +2518,21 @@ mark,
 .viewer-toolbar a {
   width: 38px;
   height: 38px;
-  border-radius: 6px;
-  border: 1px solid #cbd5df;
-  background: #ffffff;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink-soft);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  transition: border-color 0.14s ease, background 0.14s ease;
+}
+
+.viewer-toolbar button:hover,
+.viewer-toolbar a:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
 }
 
 .viewer-label {
@@ -1664,36 +2542,13 @@ mark,
   white-space: nowrap;
   padding: 5px 8px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.88);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
   border: 1px solid var(--line);
-  color: #344150;
+  color: var(--ink-soft);
   font-size: 12px;
 }
 
-.empty-panel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 120px;
-  border: 1px dashed #c3ced8;
-  border-radius: 6px;
-  color: var(--muted);
-  background: var(--surface-soft);
-  text-align: center;
-  padding: 12px;
-}
-
-.empty-panel.tall {
-  min-height: 320px;
-}
-
-.route-loading {
-  min-height: 60vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #667586;
-}
+/* --- Responsive ---------------------------------------------------------- */
 
 @media (max-width: 1120px) {
   .app-shell,
@@ -1730,15 +2585,19 @@ mark,
     position: static;
     height: auto;
     border-right: 0;
-    border-bottom: 1px solid #d8e0e7;
+    border-bottom: 1px solid var(--line);
   }
 
   .nav-list {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
+  .account-block {
+    margin-top: 0;
+  }
+
   .reactor-readout {
-    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
   }
 
   .list-panel,
@@ -1761,7 +2620,7 @@ mark,
 
   .page-header h1,
   .hero-copy h2 {
-    font-size: 23px;
+    font-size: 22px;
   }
 
   .stat-row,
@@ -1830,7 +2689,6 @@ mark,
     min-height: 44px;
     padding: 0 12px;
     border-left: 3px solid transparent;
-    border-bottom: 0;
   }
 
   .sidebar.menu-open .nav-list {
@@ -1842,24 +2700,12 @@ mark,
     display: block;
   }
 
-  .nav-list a.active {
-    padding: 0 12px;
-  }
-
-  .nav-list a.active,
-  .nav-list a:hover {
-    border-left-color: var(--accent);
-    border-bottom-color: transparent;
-  }
-
-  .sidebar-note {
+  .account-block {
     display: none;
-    padding: 10px;
-    margin-top: 0;
   }
 
-  .sidebar.menu-open .sidebar-note {
-    display: flex;
+  .sidebar.menu-open .account-block {
+    display: grid;
   }
 
   .hero-band,
@@ -1888,10 +2734,6 @@ mark,
     padding: 12px;
   }
 
-  .readout-grid {
-    min-height: 180px;
-  }
-
   .tag-row,
   .timeline,
   .science-meta {
@@ -1906,10 +2748,6 @@ mark,
   .science-meta span {
     flex: 0 0 auto;
     max-width: 82vw;
-  }
-
-  .run-line {
-    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .split-page .run-list {
@@ -1927,10 +2765,6 @@ mark,
 
   .markdown-body {
     padding: 16px;
-  }
-
-  .formula-card .katex-display {
-    font-size: 0.92em;
   }
 
   .viewer-meta {
@@ -1968,9 +2802,9 @@ mark,
 
   .admin-row > [data-label]::before {
     content: attr(data-label);
-    color: #667586;
+    color: var(--muted);
     font-size: 12px;
-    font-weight: 800;
+    font-weight: 700;
     text-transform: uppercase;
   }
 
@@ -1990,7 +2824,7 @@ mark,
 
   .page-header h1,
   .hero-copy h2 {
-    font-size: 21px;
+    font-size: 20px;
   }
 
   .primary-action,
@@ -2012,5 +2846,18 @@ mark,
 
   .split-page .run-list {
     max-height: 260px;
+  }
+}
+
+/* --- Reduced motion ------------------------------------------------------ */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/web/ui/src/theme.ts
+++ b/web/ui/src/theme.ts
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark" | "system";
+
+const STORAGE_KEY = "thorium-theme";
+const THEME_EVENT = "thorium-themechange";
+
+export function getStoredTheme(): ThemeMode {
+  if (typeof localStorage === "undefined") return "system";
+  const value = localStorage.getItem(STORAGE_KEY);
+  return value === "light" || value === "dark" || value === "system" ? value : "system";
+}
+
+/** Resolve a mode to the concrete scheme currently in effect. */
+export function resolvedScheme(mode: ThemeMode): "light" | "dark" {
+  if (mode === "system") {
+    return typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return mode;
+}
+
+/** Apply a theme mode to <html> and notify subscribers (charts, etc.). */
+export function applyTheme(mode: ThemeMode): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (mode === "system") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", mode);
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage failures (private mode, etc.).
+  }
+  window.dispatchEvent(new CustomEvent(THEME_EVENT));
+}
+
+/** Read the theme mode + resolved scheme, staying in sync with changes. */
+export function useTheme(): { mode: ThemeMode; scheme: "light" | "dark"; setMode: (mode: ThemeMode) => void } {
+  const [mode, setModeState] = useState<ThemeMode>(getStoredTheme);
+  const [scheme, setScheme] = useState<"light" | "dark">(() => resolvedScheme(getStoredTheme()));
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const sync = () => {
+      const current = getStoredTheme();
+      setModeState(current);
+      setScheme(resolvedScheme(current));
+    };
+    window.addEventListener(THEME_EVENT, sync);
+    media.addEventListener("change", sync);
+    return () => {
+      window.removeEventListener(THEME_EVENT, sync);
+      media.removeEventListener("change", sync);
+    };
+  }, []);
+
+  return {
+    mode,
+    scheme,
+    setMode: (next: ThemeMode) => {
+      applyTheme(next);
+      setModeState(next);
+      setScheme(resolvedScheme(next));
+    }
+  };
+}
+
+export interface ChartTokens {
+  scheme: "light" | "dark";
+  accent: string;
+  axis: string;
+  grid: string;
+  label: string;
+  muted: string;
+  series: string[];
+}
+
+function readVar(styles: CSSStyleDeclaration, name: string, fallback: string): string {
+  const value = styles.getPropertyValue(name).trim();
+  return value || fallback;
+}
+
+/** Chart colors sourced from the CSS design tokens, refreshed on theme change. */
+export function useChartTokens(): ChartTokens {
+  const compute = (): ChartTokens => {
+    if (typeof window === "undefined") {
+      return { scheme: "light", accent: "#0f766e", axis: "#51606f", grid: "#dfe5ea", label: "#303944", muted: "#5b6a74", series: ["#0f766e"] };
+    }
+    const styles = getComputedStyle(document.documentElement);
+    const scheme = resolvedScheme(getStoredTheme());
+    return {
+      scheme,
+      accent: readVar(styles, "--accent", "#0f766e"),
+      axis: readVar(styles, "--chart-axis", "#51606f"),
+      grid: readVar(styles, "--chart-grid", "#dfe5ea"),
+      label: readVar(styles, "--chart-label", "#303944"),
+      muted: readVar(styles, "--muted", "#5b6a74"),
+      series: [
+        readVar(styles, "--chart-1", "#0f766e"),
+        readVar(styles, "--chart-2", "#2b6cb0"),
+        readVar(styles, "--chart-3", "#a1660a"),
+        readVar(styles, "--chart-4", "#8a5cd0"),
+        readVar(styles, "--chart-5", "#b23a2b"),
+        readVar(styles, "--chart-6", "#4f8a5b")
+      ]
+    };
+  };
+
+  const [tokens, setTokens] = useState<ChartTokens>(compute);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const refresh = () => setTokens(compute());
+    window.addEventListener(THEME_EVENT, refresh);
+    media.addEventListener("change", refresh);
+    return () => {
+      window.removeEventListener(THEME_EVENT, refresh);
+      media.removeEventListener("change", refresh);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return tokens;
+}
+
+/** Whether the user prefers reduced motion (for chart/3D animations). */
+export function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/web/ui/src/types.ts
+++ b/web/ui/src/types.ts
@@ -101,6 +101,13 @@ export interface SimulationDraft {
   prefer_gpu: boolean;
 }
 
+export interface DraftValidationResponse {
+  valid: boolean;
+  message: string;
+  normalized_yaml?: string | null;
+  editable_parameters: EditableParameter[];
+}
+
 export interface AuthSession {
   email: string;
   is_admin: boolean;


### PR DESCRIPTION
## Summary

Overhaul of the `web/ui` React app, guided by one rule: **every visible figure, bar, badge, or equation must trace to real data — or be removed.**

**Removed / finished half-baked features**
- **Fake dashboard bar chart** (six bars at hardcoded CSS heights, unrelated to data) → removed; replaced with a real run-status distribution strip driven by actual run counts.
- **Docs "Core Relations" formula rail** (the same 3 static equations on *every* doc) → removed; replaced with a real, de-duplicated anchor outline built from the document's own headings, plus honest section / word-count / read-time metadata.
- **Unused `POST /api/cases/{name}/validate-draft`** → wired up as a "Check inputs" action that validates the draft and previews the normalized case YAML.
- **Run `progress` and per-parameter `step`** (produced by the backend, ignored by the UI) → now rendered / honored; the fabricated 4-phase fallback timeline → honest "no phase plan recorded" state; Builder sweep/scenario controls now dim when their phase isn't selected instead of silently doing nothing.

**Polish**
- Fully tokenized design system with **light / system / dark** themes (`prefers-color-scheme` + toggle), themed ECharts and the 3D canvas, a complete hover/active/disabled/focus state matrix, tabular figures, and reduced-motion support.
- **Loading / error / empty states** across every page (previously blank panels or errors shown as empty), plus top-level and 3D-canvas **error boundaries** that reset on navigation.
- Real URL state (`/cases/:name` deep links, dashboard drill-down), `aria-pressed` / `aria-current`, back-links, coherent nav labels, and replacement of the click-to-expand-everything crutch with proper truncation.

New shared primitives: `Truncate`, `StateBlock`, `StatusBadge`, `ProgressBar`, `ErrorBoundary`, `theme.ts`. No backend changes. Also adds `scripts/dev_preview_server.py`, a stdlib dev helper that serves the built SPA against the real filesystem-backed repository for local preview.

## Linked Issues

Closes #

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Validation / benchmark evidence
- [x] Infrastructure / tooling

## Verification

- [ ] `.\scripts\Run-Tests.cmd`
- [ ] Focused Python tests:
- [x] `npm.cmd run build` from `web/ui`
- [x] `npm.cmd run test` from `web/ui` (9/9 pass)
- [x] Browser clickthrough: Dashboard, Cases, Builder, Runs, Science, 3D — exercised against real data (8 cases, 40 runs, 15 docs) with zero console errors across light/system/dark. 3D viewer verified for theming/wiring; live canvas render not captured in the sandbox.
- [ ] Not applicable; explain:

An adversarial multi-agent review of the diff surfaced 4 self-introduced regressions (broken selected-row reveal, error boundary not resetting on navigation, duplicate-heading anchor collisions, a dropped CSS rule) — all fixed and re-verified live.

## Validation / Safety Notes

- UI-only change; no simulation, physics, or benchmark logic touched, and no canonical config generation paths changed.
- The new "Check inputs" flow calls the existing read-only `validate-draft` endpoint (validates in a temp dir; does not launch runs or write bundles). Validation is advisory and never blocks the Start button on a network failure.

## Result Bundle Notes

- Case: n/a — no runs launched by this change.
- Run ID or artifact path: n/a (verified against existing result bundles).
- Canonical `configs/cases/*/case.yaml` files were not mutated by browser-launched runs: yes (no runs launched; backend run-safety unchanged).
