### PR TITLE
Harden web security, evidence contract, and CI trust gate

### DIFF
--- a/.github/workflows/msre-openmc-benchmark.yml
+++ b/.github/workflows/msre-openmc-benchmark.yml
@@ -1,6 +1,8 @@
 name: MSRE OpenMC benchmark
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -38,6 +40,15 @@ jobs:
         shell: bash
         run: docker compose run --rm app python -m thorium_reactor.cli qa --format json
 
+      - name: Run readiness and provenance trust-contract tests
+        shell: bash
+        run: |
+          docker compose run --rm app python -m pytest \
+            tests/test_evidence_contract.py \
+            tests/test_reporting.py \
+            tests/test_paths.py \
+            tests/test_runtime_context.py -q
+
       - name: Generate dry-run MSRE report bundle
         shell: bash
         run: |
@@ -45,6 +56,12 @@ jobs:
             --run-id "${PREFLIGHT_RUN_ID}" --no-solver
           docker compose run --rm app python -m thorium_reactor.cli report "${CASE_NAME}" \
             --run-id "${PREFLIGHT_RUN_ID}"
+
+      - name: Verify generated bundle evidence contract agrees
+        shell: bash
+        run: |
+          docker compose run --rm app python -m thorium_reactor.cli verify-bundle \
+            "${CASE_NAME}" --run-id "${PREFLIGHT_RUN_ID}"
 
       - name: Upload dry-run preflight bundle
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,12 @@ services:
       THORIUM_REACTOR_ADMIN_EMAILS: "${THORIUM_REACTOR_ADMIN_EMAILS:-seamusdgallagher@gmail.com}"
       THORIUM_REACTOR_RATE_LIMIT_PER_DAY: "${THORIUM_REACTOR_RATE_LIMIT_PER_DAY:-1}"
       THORIUM_REACTOR_RATE_LIMIT_TIMEZONE: "${THORIUM_REACTOR_RATE_LIMIT_TIMEZONE:-America/New_York}"
+      # Required to trust the Access identity header when access is required:
+      # the access proxy must attach the same value as x-thorium-proxy-secret.
+      THORIUM_REACTOR_PROXY_SHARED_SECRET: "${THORIUM_REACTOR_PROXY_SHARED_SECRET:-}"
+      # Transport peers (IPs/CIDRs) allowed to use the anonymous local-dev
+      # fallback when access is required. Loopback is always trusted.
+      THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS: "${THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS:-}"
     command: ["uvicorn", "thorium_reactor.web.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "18488"]
     networks:
       default:

--- a/src/thorium_reactor/cli.py
+++ b/src/thorium_reactor/cli.py
@@ -41,9 +41,11 @@ from thorium_reactor.paths import (
     refresh_bundle_artifact_statuses,
     snapshot_bundle_artifacts,
 )
+from thorium_reactor.evidence import build_evidence_status, load_canonical_artifact_status
 from thorium_reactor.qa import build_requirements_summary
 from thorium_reactor.reporting.plots import generate_summary_plots, generate_validation_plot, load_plot_manifest
-from thorium_reactor.reporting.reports import generate_report
+from thorium_reactor.reporting.reports import build_presentation_qa, generate_report
+from thorium_reactor.sidecar_schemas import validate_bundle_sidecars
 from thorium_reactor.transient_sweep import DEFAULT_TRANSIENT_SWEEP_SAMPLES
 from thorium_reactor.uncertainty import DEFAULT_UNCERTAINTY_SWEEP_SAMPLES
 
@@ -77,6 +79,7 @@ def build_parser() -> argparse.ArgumentParser:
         "report",
         "render",
         "benchmark",
+        "verify-bundle",
         "transient",
         "transient-sweep",
         *UNCERTAINTY_COMMANDS,
@@ -212,577 +215,610 @@ def main(argv: list[str] | None = None) -> int:
     stage_artifacts_before = snapshot_bundle_artifacts(bundle)
     stage_command = _stage_command_from_argv(effective_argv, args.command)
 
-    if args.command == "build":
-        built = build_case(config, bundle.openmc_dir, benchmark=benchmark)
-        bundle.write_json("geometry_description.json", built.geometry_description)
-        build_manifest = dict(built.manifest)
-        build_manifest["workflow_capabilities"] = sorted(get_case_capabilities(config))
-        build_manifest["visualization_state"] = _build_visualization_state(bundle)
-        build_manifest["input_provenance"] = provenance
-        bundle.write_json("build_manifest.json", build_manifest)
-        if built.model is not None:
-            built.model.export_to_xml(directory=str(bundle.openmc_dir))
-        artifact_status = refresh_bundle_artifact_statuses(bundle, summary={"neutronics": {"status": "dry-run"}})
-        build_manifest["artifact_status"] = artifact_status
-        bundle.write_json("build_manifest.json", build_manifest)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=build_manifest)
-        print(bundle.root)
-        return 0
+    try:
+        if args.command == "build":
+            built = build_case(config, bundle.openmc_dir, benchmark=benchmark)
+            bundle.write_json("geometry_description.json", built.geometry_description)
+            build_manifest = dict(built.manifest)
+            build_manifest["workflow_capabilities"] = sorted(get_case_capabilities(config))
+            build_manifest["visualization_state"] = _build_visualization_state(bundle)
+            build_manifest["input_provenance"] = provenance
+            bundle.write_json("build_manifest.json", build_manifest)
+            if built.model is not None:
+                built.model.export_to_xml(directory=str(bundle.openmc_dir))
+            artifact_status = refresh_bundle_artifact_statuses(bundle, summary={"neutronics": {"status": "dry-run"}})
+            build_manifest["artifact_status"] = artifact_status
+            bundle.write_json("build_manifest.json", build_manifest)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=build_manifest)
+            print(bundle.root)
+            return 0
 
-    if args.command == "run":
-        summary = run_case(
-            config,
-            bundle,
-            benchmark=benchmark,
-            solver_enabled=not args.no_solver,
-            provenance=provenance,
-            repo_root=repo_root,
-        )
-        print(bundle.root)
-        print(summary["neutronics"]["status"])
-        if summary["neutronics"].get("message"):
-            print(summary["neutronics"]["message"])
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        return 0
-
-    if args.command == "transient":
-        from thorium_reactor.transient import run_transient_case
-
-        summary_path = bundle.root / "summary.json"
-        if summary_path.exists():
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        else:
+        if args.command == "run":
             summary = run_case(
                 config,
                 bundle,
                 benchmark=benchmark,
-                solver_enabled=False,
+                solver_enabled=not args.no_solver,
                 provenance=provenance,
                 repo_root=repo_root,
             )
-        transient = run_transient_case(
-            config,
-            bundle,
-            summary,
-            scenario_name=args.scenario,
-            provenance=provenance,
-        )
-        bundle.write_json("summary.json", summary)
-        generate_summary_plots(bundle, summary)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        print(bundle.root)
-        print(transient["metrics"]["peak_power_fraction"])
-        return 0
+            print(bundle.root)
+            print(summary["neutronics"]["status"])
+            if summary["neutronics"].get("message"):
+                print(summary["neutronics"]["message"])
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            return 0
 
-    if args.command == "transient-sweep":
-        from thorium_reactor.transient_sweep import run_transient_sweep_case
+        if args.command == "transient":
+            from thorium_reactor.transient import run_transient_case
 
-        summary_path = bundle.root / "summary.json"
-        if summary_path.exists():
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        else:
-            summary = run_case(
-                config,
-                bundle,
-                benchmark=benchmark,
-                solver_enabled=False,
-                provenance=provenance,
-                repo_root=repo_root,
-            )
-        transient_sweep = run_transient_sweep_case(
-            config,
-            bundle,
-            summary,
-            scenario_name=args.scenario,
-            samples=args.samples,
-            seed=args.seed,
-            prefer_gpu=args.prefer_gpu,
-            backend=args.backend,
-            dtype=args.dtype,
-            provenance=provenance,
-        )
-        bundle.write_json("summary.json", summary)
-        generate_summary_plots(bundle, summary)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        print(bundle.root)
-        print(transient_sweep["backend"])
-        print(transient_sweep["metrics"]["peak_power_fraction_p95"])
-        return 0
-
-    if args.command == "uncertainty-sweep":
-        from thorium_reactor.uncertainty import run_docker_uncertainty_sweep, run_uncertainty_sweep_case
-
-        if args.docker_openmc and os.environ.get("THORIUM_REACTOR_RUNTIME_SERVICE") != "openmc":
-            execution = run_docker_uncertainty_sweep(
-                repo_root,
-                config.name,
-                bundle.run_id,
-                samples=args.samples,
-                seed=args.seed,
-                sampler=args.sampler,
-                max_parallel=args.max_parallel,
-                resume=args.resume,
-                require_source_backed=args.require_source_backed,
-            )
-            bundle.write_json("uncertainty_execution.json", execution)
-            if execution["returncode"] != 0:
-                raise RuntimeError(execution.get("stderr") or "Docker OpenMC uncertainty sweep failed.")
             summary_path = bundle.root / "summary.json"
-            if not summary_path.exists():
-                raise FileNotFoundError(
-                    f"No summary found for uncertainty sweep case '{config.name}' in {bundle.root}."
+            if summary_path.exists():
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            else:
+                summary = run_case(
+                    config,
+                    bundle,
+                    benchmark=benchmark,
+                    solver_enabled=False,
+                    provenance=provenance,
+                    repo_root=repo_root,
                 )
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        else:
-            summary = run_uncertainty_sweep_case(
-                repo_root,
+            transient = run_transient_case(
                 config,
                 bundle,
-                benchmark,
+                summary,
+                scenario_name=args.scenario,
+                provenance=provenance,
+            )
+            bundle.write_json("summary.json", summary)
+            generate_summary_plots(bundle, summary)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            print(bundle.root)
+            print(transient["metrics"]["peak_power_fraction"])
+            return 0
+
+        if args.command == "transient-sweep":
+            from thorium_reactor.transient_sweep import run_transient_sweep_case
+
+            summary_path = bundle.root / "summary.json"
+            if summary_path.exists():
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            else:
+                summary = run_case(
+                    config,
+                    bundle,
+                    benchmark=benchmark,
+                    solver_enabled=False,
+                    provenance=provenance,
+                    repo_root=repo_root,
+                )
+            transient_sweep = run_transient_sweep_case(
+                config,
+                bundle,
+                summary,
+                scenario_name=args.scenario,
                 samples=args.samples,
                 seed=args.seed,
-                sampler=args.sampler,
-                max_parallel=args.max_parallel,
-                resume=args.resume,
-                require_source_backed=args.require_source_backed,
+                prefer_gpu=args.prefer_gpu,
+                backend=args.backend,
+                dtype=args.dtype,
                 provenance=provenance,
             )
-        validation = validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
-        generate_validation_plot(bundle, validation)
-        plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
-        geometry_assets = None
-        summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
-        bundle.write_json("summary.json", summary)
-        report = generate_report(
-            config.name,
-            config.data,
-            bundle.root / "summary.json",
-            bundle.root / "validation.json",
-            None,
-            benchmark,
-            plot_assets,
-            provenance=provenance,
-        )
-        bundle.write_text("report.md", report)
-        summary = _refresh_benchmark_evidence(bundle, config.data, benchmark, provenance)
-        report = generate_report(
-            config.name,
-            config.data,
-            bundle.root / "summary.json",
-            bundle.root / "validation.json",
-            geometry_assets,
-            benchmark,
-            plot_assets,
-            provenance=provenance,
-        )
-        bundle.write_text("report.md", report)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
-        print(bundle.root)
-        print(summary.get("uncertainty_sweep", {}).get("coverage_status", "missing"))
-        return 0
+            bundle.write_json("summary.json", summary)
+            generate_summary_plots(bundle, summary)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            print(bundle.root)
+            print(transient_sweep["backend"])
+            print(transient_sweep["metrics"]["peak_power_fraction_p95"])
+            return 0
 
-    if args.command == "runtime-benchmark":
-        from thorium_reactor.runtime_benchmark import parse_backend_list, run_runtime_benchmark_case
+        if args.command == "uncertainty-sweep":
+            from thorium_reactor.uncertainty import run_docker_uncertainty_sweep, run_uncertainty_sweep_case
 
-        summary_path = bundle.root / "summary.json"
-        if summary_path.exists():
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        else:
-            summary = run_case(
-                config,
-                bundle,
-                benchmark=benchmark,
-                solver_enabled=False,
-                provenance=provenance,
-                repo_root=repo_root,
-            )
-        runtime_benchmark = run_runtime_benchmark_case(
-            config,
-            bundle,
-            summary,
-            scenario_name=args.scenario,
-            samples=args.samples,
-            seed=args.seed,
-            backends=parse_backend_list(args.backends),
-            dtype=args.dtype,
-            fail_on_gpu_fallback=args.fail_on_gpu_fallback,
-            provenance=provenance,
-        )
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        print(bundle.root)
-        print(runtime_benchmark["recommendation"].get("backend"))
-        print(runtime_benchmark["recommendation"].get("speedup_vs_reference"))
-        return 0
-
-    if args.command == "transport":
-        from thorium_reactor.transport import run_transport_case
-
-        summary_path = bundle.root / "summary.json"
-        if summary_path.exists():
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        else:
-            summary = run_case(
-                config,
-                bundle,
-                benchmark=benchmark,
-                solver_enabled=False,
-                provenance=provenance,
-                repo_root=repo_root,
-            )
-        transport = run_transport_case(config, bundle, summary)
-        generate_summary_plots(bundle, summary)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        print(bundle.root)
-        print(transport["status"])
-        print(transport["conservation_residual"])
-        return 0
-
-    if args.command == "deplete":
-        from thorium_reactor.depletion import run_depletion_case
-
-        summary_path = bundle.root / "summary.json"
-        if summary_path.exists():
-            summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        else:
-            summary = run_case(
-                config,
-                bundle,
-                benchmark=benchmark,
-                solver_enabled=False,
-                provenance=provenance,
-                repo_root=repo_root,
-            )
-        depletion = run_depletion_case(config, bundle, summary)
-        generate_summary_plots(bundle, summary)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        print(bundle.root)
-        print(depletion["status"])
-        print(depletion["atom_balance_residual"])
-        return 0
-
-    if args.command == "economics":
-        plan = run_economics_case(
-            config,
-            bundle,
-            scenario_name=args.scenario,
-            project_start=args.project_start,
-            force=args.force,
-        )
-        summary = json.loads((bundle.root / "summary.json").read_text(encoding="utf-8"))
-        generate_summary_plots(bundle, summary)
-        report_path = bundle.root / "report.md"
-        if report_path.exists():
-            validation_path = bundle.root / "validation.json"
-            geometry_assets = None
-            render_assets_path = bundle.root / "render_assets.json"
-            if render_assets_path.exists():
-                geometry_assets = json.loads(render_assets_path.read_text(encoding="utf-8"))
+            if args.docker_openmc and os.environ.get("THORIUM_REACTOR_RUNTIME_SERVICE") != "openmc":
+                execution = run_docker_uncertainty_sweep(
+                    repo_root,
+                    config.name,
+                    bundle.run_id,
+                    samples=args.samples,
+                    seed=args.seed,
+                    sampler=args.sampler,
+                    max_parallel=args.max_parallel,
+                    resume=args.resume,
+                    require_source_backed=args.require_source_backed,
+                )
+                bundle.write_json("uncertainty_execution.json", execution)
+                if execution["returncode"] != 0:
+                    raise RuntimeError(execution.get("stderr") or "Docker OpenMC uncertainty sweep failed.")
+                summary_path = bundle.root / "summary.json"
+                if not summary_path.exists():
+                    raise FileNotFoundError(
+                        f"No summary found for uncertainty sweep case '{config.name}' in {bundle.root}."
+                    )
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            else:
+                summary = run_uncertainty_sweep_case(
+                    repo_root,
+                    config,
+                    bundle,
+                    benchmark,
+                    samples=args.samples,
+                    seed=args.seed,
+                    sampler=args.sampler,
+                    max_parallel=args.max_parallel,
+                    resume=args.resume,
+                    require_source_backed=args.require_source_backed,
+                    provenance=provenance,
+                )
+            validation = validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
+            generate_validation_plot(bundle, validation)
             plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
+            geometry_assets = None
             summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
             bundle.write_json("summary.json", summary)
             report = generate_report(
                 config.name,
                 config.data,
                 bundle.root / "summary.json",
-                validation_path if validation_path.exists() else None,
+                bundle.root / "validation.json",
+                None,
+                benchmark,
+                plot_assets,
+                provenance=provenance,
+            )
+            bundle.write_text("report.md", report)
+            summary = _refresh_benchmark_evidence(bundle, config.data, benchmark, provenance)
+            report = generate_report(
+                config.name,
+                config.data,
+                bundle.root / "summary.json",
+                bundle.root / "validation.json",
                 geometry_assets,
                 benchmark,
                 plot_assets,
                 provenance=provenance,
             )
             bundle.write_text("report.md", report)
-        else:
-            summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
-            bundle.write_json("summary.json", summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
-        print(bundle.root)
-        print(plan["status"])
-        if plan["finance"].get("status") == "completed":
-            print(plan["finance"]["outputs"]["lcoe_usd_per_mwh"])
-            print(plan["schedule"]["commercial_operation_date"])
-        return 0
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
+            print(bundle.root)
+            print(summary.get("uncertainty_sweep", {}).get("coverage_status", "missing"))
+            return 0
 
-    if args.command == "moose":
-        result = run_moose_integration(
-            config,
-            bundle,
-            benchmark=benchmark,
-            provenance=provenance,
-            execute=args.run_external,
-        )
-        summary_path = bundle.root / "summary.json"
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        persist_integration_result(bundle, summary, "moose", result)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
-        print(bundle.root)
-        print(result["status"])
-        return 0
+        if args.command == "runtime-benchmark":
+            from thorium_reactor.runtime_benchmark import parse_backend_list, run_runtime_benchmark_case
 
-    if args.command == "scale":
-        result = run_scale_integration(
-            config,
-            bundle,
-            benchmark=benchmark,
-            provenance=provenance,
-            execute=args.run_external,
-        )
-        summary_path = bundle.root / "summary.json"
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        persist_integration_result(bundle, summary, "scale", result)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
-        print(bundle.root)
-        print(result["status"])
-        return 0
-
-    if args.command == "thermochimica":
-        result = run_thermochimica_integration(
-            config,
-            bundle,
-            benchmark=benchmark,
-            provenance=provenance,
-            execute=args.run_external,
-        )
-        summary_path = bundle.root / "summary.json"
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        persist_integration_result(bundle, summary, "thermochimica", result)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
-        print(bundle.root)
-        print(result["status"])
-        return 0
-
-    if args.command == "saltproc":
-        result = run_saltproc_integration(
-            config,
-            bundle,
-            benchmark=benchmark,
-            provenance=provenance,
-            execute=args.run_external,
-        )
-        summary_path = bundle.root / "summary.json"
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        persist_integration_result(bundle, summary, "saltproc", result)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
-        print(bundle.root)
-        print(result["status"])
-        return 0
-
-    if args.command == "moltres":
-        result = run_moltres_integration(
-            config,
-            bundle,
-            benchmark=benchmark,
-            provenance=provenance,
-            execute=args.run_external,
-        )
-        summary_path = bundle.root / "summary.json"
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        persist_integration_result(bundle, summary, "moltres", result)
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
-        print(bundle.root)
-        print(result["status"])
-        return 0
-
-    if args.command == "validate":
-        result = validate_case(config, bundle, benchmark=benchmark, provenance=provenance)
-        summary_path = bundle.root / "summary.json"
-        summary = json.loads(summary_path.read_text(encoding="utf-8")) if summary_path.exists() else {}
-        refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status="completed" if result.get("passed") else "failed")
-        print(result["passed"])
-        return 0
-
-    if args.command == "render":
-        summary_path = bundle.root / "summary.json"
-        if not summary_path.exists():
-            raise FileNotFoundError(
-                f"No summary found for case '{config.name}' in {bundle.root}. "
-                "Run `reactor run <case>` first or specify an existing run id."
+            summary_path = bundle.root / "summary.json"
+            if summary_path.exists():
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            else:
+                summary = run_case(
+                    config,
+                    bundle,
+                    benchmark=benchmark,
+                    solver_enabled=False,
+                    provenance=provenance,
+                    repo_root=repo_root,
+                )
+            runtime_benchmark = run_runtime_benchmark_case(
+                config,
+                bundle,
+                summary,
+                scenario_name=args.scenario,
+                samples=args.samples,
+                seed=args.seed,
+                backends=parse_backend_list(args.backends),
+                dtype=args.dtype,
+                fail_on_gpu_fallback=args.fail_on_gpu_fallback,
+                provenance=provenance,
             )
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        validation_path = bundle.root / "validation.json"
-        if validation_path.exists():
-            validation = json.loads(validation_path.read_text(encoding="utf-8"))
-        else:
-            validation = validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
-
-        geometry_description_path = bundle.root / "geometry_description.json"
-        if geometry_description_path.exists():
-            geometry_description = json.loads(geometry_description_path.read_text(encoding="utf-8"))
-        else:
-            built = build_case(config, bundle.openmc_dir, benchmark=benchmark)
-            geometry_description = built.geometry_description
-            bundle.write_json("geometry_description.json", geometry_description)
-
-        assets = export_geometry(
-            geometry_description,
-            bundle.geometry_exports_dir,
-            summary=summary,
-            validation=validation,
-        )
-        bundle.write_json("render_assets.json", assets)
-        summary["visualization_state"] = _build_visualization_state(bundle, assets=assets)
-        bundle.write_json("summary.json", summary)
-        build_manifest_path = bundle.root / "build_manifest.json"
-        if build_manifest_path.exists():
-            build_manifest = json.loads(build_manifest_path.read_text(encoding="utf-8"))
-            build_manifest["geometry_assets"] = assets
-            build_manifest["visualization_state"] = _build_visualization_state(bundle, assets=assets)
-            build_manifest["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
-            bundle.write_json("build_manifest.json", build_manifest)
-        else:
             refresh_bundle_artifact_statuses(bundle, summary=summary)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
-        print(json.dumps(assets, indent=2))
-        return 0
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            print(bundle.root)
+            print(runtime_benchmark["recommendation"].get("backend"))
+            print(runtime_benchmark["recommendation"].get("speedup_vs_reference"))
+            return 0
 
-    if args.command == "report":
-        summary_path = bundle.root / "summary.json"
-        if not summary_path.exists():
-            raise FileNotFoundError(
-                f"No summary found for case '{config.name}' in {bundle.root}. "
-                "Run `reactor run <case>` first or specify an existing run id."
+        if args.command == "transport":
+            from thorium_reactor.transport import run_transport_case
+
+            summary_path = bundle.root / "summary.json"
+            if summary_path.exists():
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            else:
+                summary = run_case(
+                    config,
+                    bundle,
+                    benchmark=benchmark,
+                    solver_enabled=False,
+                    provenance=provenance,
+                    repo_root=repo_root,
+                )
+            transport = run_transport_case(config, bundle, summary)
+            generate_summary_plots(bundle, summary)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            print(bundle.root)
+            print(transport["status"])
+            print(transport["conservation_residual"])
+            return 0
+
+        if args.command == "deplete":
+            from thorium_reactor.depletion import run_depletion_case
+
+            summary_path = bundle.root / "summary.json"
+            if summary_path.exists():
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            else:
+                summary = run_case(
+                    config,
+                    bundle,
+                    benchmark=benchmark,
+                    solver_enabled=False,
+                    provenance=provenance,
+                    repo_root=repo_root,
+                )
+            depletion = run_depletion_case(config, bundle, summary)
+            generate_summary_plots(bundle, summary)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            print(bundle.root)
+            print(depletion["status"])
+            print(depletion["atom_balance_residual"])
+            return 0
+
+        if args.command == "economics":
+            plan = run_economics_case(
+                config,
+                bundle,
+                scenario_name=args.scenario,
+                project_start=args.project_start,
+                force=args.force,
             )
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        generate_summary_plots(bundle, summary)
-        validation_path = bundle.root / "validation.json"
-        needs_validation = not validation_path.exists()
-        if validation_path.exists():
-            try:
-                json.loads(validation_path.read_text(encoding="utf-8"))
-            except JSONDecodeError:
-                needs_validation = True
-        if needs_validation:
-            validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
-        validation = json.loads(validation_path.read_text(encoding="utf-8"))
-        generate_validation_plot(bundle, validation)
-        geometry_assets = None
-        render_assets_path = bundle.root / "render_assets.json"
-        if render_assets_path.exists():
-            geometry_assets = json.loads(render_assets_path.read_text(encoding="utf-8"))
-        else:
-            build_manifest_path = bundle.root / "build_manifest.json"
-            if build_manifest_path.exists():
-                build_manifest = json.loads(build_manifest_path.read_text(encoding="utf-8"))
-                geometry_assets = build_manifest.get("geometry_assets")
-        plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
-        summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
-        bundle.write_json("summary.json", summary)
-        report = generate_report(
-            config.name,
-            config.data,
-            summary_path,
-            validation_path,
-            geometry_assets,
-            benchmark,
-            plot_assets,
-            provenance=provenance,
-        )
-        report_path = bundle.write_text("report.md", report)
-        summary = _refresh_benchmark_evidence(bundle, config.data, benchmark, provenance)
-        report = generate_report(
-            config.name,
-            config.data,
-            summary_path,
-            validation_path,
-            geometry_assets,
-            benchmark,
-            plot_assets,
-            provenance=provenance,
-        )
-        report_path = bundle.write_text("report.md", report)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
-        print(report_path)
-        return 0
+            summary = json.loads((bundle.root / "summary.json").read_text(encoding="utf-8"))
+            generate_summary_plots(bundle, summary)
+            report_path = bundle.root / "report.md"
+            if report_path.exists():
+                validation_path = bundle.root / "validation.json"
+                geometry_assets = None
+                render_assets_path = bundle.root / "render_assets.json"
+                if render_assets_path.exists():
+                    geometry_assets = json.loads(render_assets_path.read_text(encoding="utf-8"))
+                plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
+                summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
+                bundle.write_json("summary.json", summary)
+                report = generate_report(
+                    config.name,
+                    config.data,
+                    bundle.root / "summary.json",
+                    validation_path if validation_path.exists() else None,
+                    geometry_assets,
+                    benchmark,
+                    plot_assets,
+                    provenance=provenance,
+                )
+                bundle.write_text("report.md", report)
+            else:
+                summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
+                bundle.write_json("summary.json", summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
+            print(bundle.root)
+            print(plan["status"])
+            if plan["finance"].get("status") == "completed":
+                print(plan["finance"]["outputs"]["lcoe_usd_per_mwh"])
+                print(plan["schedule"]["commercial_operation_date"])
+            return 0
 
-    if args.command == "benchmark":
-        docker_status = get_docker_runtime_status() if (args.docker_openmc or openmc is None) else None
-        runtime, error_message = resolve_benchmark_runtime(
-            docker_requested=args.docker_openmc,
-            local_openmc_available=openmc is not None,
-            docker_status=docker_status,
-        )
-        if runtime == "docker":
-            execution = run_solver_backed_benchmark(repo_root, config.name, bundle.run_id)
-            bundle.write_json("benchmark_execution.json", execution)
-        elif runtime == "local":
-            summary = run_case(
+        if args.command == "moose":
+            result = run_moose_integration(
                 config,
                 bundle,
                 benchmark=benchmark,
-                solver_enabled=True,
                 provenance=provenance,
+                execute=args.run_external,
                 repo_root=repo_root,
             )
-            bundle.write_json(
-                "benchmark_execution.json",
-                {
-                    "runtime": "local-openmc",
-                    "summary_status": summary.get("neutronics", {}).get("status"),
-                },
-            )
-        else:
-            raise RuntimeError(error_message or missing_openmc_runtime_message(command_name="benchmark"))
+            summary_path = bundle.root / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            persist_integration_result(bundle, summary, "moose", result)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
+            print(bundle.root)
+            print(result["status"])
+            return 0
 
-        summary_path = bundle.root / "summary.json"
-        if not summary_path.exists():
-            raise FileNotFoundError(
-                f"No summary found for benchmark case '{config.name}' in {bundle.root}. "
-                "The solver-backed benchmark run did not produce a summary bundle."
+        if args.command == "scale":
+            result = run_scale_integration(
+                config,
+                bundle,
+                benchmark=benchmark,
+                provenance=provenance,
+                execute=args.run_external,
+                repo_root=repo_root,
             )
-        summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        generate_summary_plots(bundle, summary)
-        validation = validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
-        generate_validation_plot(bundle, validation)
-        geometry_assets = None
-        render_assets_path = bundle.root / "render_assets.json"
-        if render_assets_path.exists():
-            geometry_assets = json.loads(render_assets_path.read_text(encoding="utf-8"))
-        else:
+            summary_path = bundle.root / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            persist_integration_result(bundle, summary, "scale", result)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
+            print(bundle.root)
+            print(result["status"])
+            return 0
+
+        if args.command == "thermochimica":
+            result = run_thermochimica_integration(
+                config,
+                bundle,
+                benchmark=benchmark,
+                provenance=provenance,
+                execute=args.run_external,
+                repo_root=repo_root,
+            )
+            summary_path = bundle.root / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            persist_integration_result(bundle, summary, "thermochimica", result)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
+            print(bundle.root)
+            print(result["status"])
+            return 0
+
+        if args.command == "saltproc":
+            result = run_saltproc_integration(
+                config,
+                bundle,
+                benchmark=benchmark,
+                provenance=provenance,
+                execute=args.run_external,
+                repo_root=repo_root,
+            )
+            summary_path = bundle.root / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            persist_integration_result(bundle, summary, "saltproc", result)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
+            print(bundle.root)
+            print(result["status"])
+            return 0
+
+        if args.command == "moltres":
+            result = run_moltres_integration(
+                config,
+                bundle,
+                benchmark=benchmark,
+                provenance=provenance,
+                execute=args.run_external,
+                repo_root=repo_root,
+            )
+            summary_path = bundle.root / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            persist_integration_result(bundle, summary, "moltres", result)
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status=result.get("status", "completed"))
+            print(bundle.root)
+            print(result["status"])
+            return 0
+
+        if args.command == "validate":
+            result = validate_case(config, bundle, benchmark=benchmark, provenance=provenance)
+            summary_path = bundle.root / "summary.json"
+            summary = json.loads(summary_path.read_text(encoding="utf-8")) if summary_path.exists() else {}
+            refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, status="completed" if result.get("passed") else "failed")
+            print(result["passed"])
+            return 0
+
+        if args.command == "render":
+            summary_path = bundle.root / "summary.json"
+            if not summary_path.exists():
+                raise FileNotFoundError(
+                    f"No summary found for case '{config.name}' in {bundle.root}. "
+                    "Run `reactor run <case>` first or specify an existing run id."
+                )
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            validation_path = bundle.root / "validation.json"
+            if validation_path.exists():
+                validation = json.loads(validation_path.read_text(encoding="utf-8"))
+            else:
+                validation = validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
+
+            geometry_description_path = bundle.root / "geometry_description.json"
+            if geometry_description_path.exists():
+                geometry_description = json.loads(geometry_description_path.read_text(encoding="utf-8"))
+            else:
+                built = build_case(config, bundle.openmc_dir, benchmark=benchmark)
+                geometry_description = built.geometry_description
+                bundle.write_json("geometry_description.json", geometry_description)
+
+            assets = export_geometry(
+                geometry_description,
+                bundle.geometry_exports_dir,
+                summary=summary,
+                validation=validation,
+            )
+            bundle.write_json("render_assets.json", assets)
+            summary["visualization_state"] = _build_visualization_state(bundle, assets=assets)
+            bundle.write_json("summary.json", summary)
             build_manifest_path = bundle.root / "build_manifest.json"
             if build_manifest_path.exists():
                 build_manifest = json.loads(build_manifest_path.read_text(encoding="utf-8"))
-                geometry_assets = build_manifest.get("geometry_assets")
-        plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
-        summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
-        bundle.write_json("summary.json", summary)
-        report = generate_report(
-            config.name,
-            config.data,
-            summary_path,
-            bundle.root / "validation.json",
-            geometry_assets,
-            benchmark,
-            plot_assets,
-            provenance=provenance,
-        )
-        bundle.write_text("report.md", report)
-        summary = _refresh_benchmark_evidence(bundle, config.data, benchmark, provenance)
-        report = generate_report(
-            config.name,
-            config.data,
-            bundle.root / "summary.json",
-            bundle.root / "validation.json",
-            geometry_assets,
-            benchmark,
-            plot_assets,
-            provenance=provenance,
-        )
-        bundle.write_text("report.md", report)
-        _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
-        print(bundle.root)
-        return 0
+                build_manifest["geometry_assets"] = assets
+                build_manifest["visualization_state"] = _build_visualization_state(bundle, assets=assets)
+                build_manifest["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
+                bundle.write_json("build_manifest.json", build_manifest)
+            else:
+                refresh_bundle_artifact_statuses(bundle, summary=summary)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary)
+            print(json.dumps(assets, indent=2))
+            return 0
 
-    return 1
+        if args.command == "report":
+            summary_path = bundle.root / "summary.json"
+            if not summary_path.exists():
+                raise FileNotFoundError(
+                    f"No summary found for case '{config.name}' in {bundle.root}. "
+                    "Run `reactor run <case>` first or specify an existing run id."
+                )
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            generate_summary_plots(bundle, summary)
+            validation_path = bundle.root / "validation.json"
+            needs_validation = not validation_path.exists()
+            if validation_path.exists():
+                try:
+                    json.loads(validation_path.read_text(encoding="utf-8"))
+                except JSONDecodeError:
+                    needs_validation = True
+            if needs_validation:
+                validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
+            validation = json.loads(validation_path.read_text(encoding="utf-8"))
+            generate_validation_plot(bundle, validation)
+            geometry_assets = None
+            render_assets_path = bundle.root / "render_assets.json"
+            if render_assets_path.exists():
+                geometry_assets = json.loads(render_assets_path.read_text(encoding="utf-8"))
+            else:
+                build_manifest_path = bundle.root / "build_manifest.json"
+                if build_manifest_path.exists():
+                    build_manifest = json.loads(build_manifest_path.read_text(encoding="utf-8"))
+                    geometry_assets = build_manifest.get("geometry_assets")
+            plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
+            summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
+            bundle.write_json("summary.json", summary)
+            report = generate_report(
+                config.name,
+                config.data,
+                summary_path,
+                validation_path,
+                geometry_assets,
+                benchmark,
+                plot_assets,
+                provenance=provenance,
+            )
+            report_path = bundle.write_text("report.md", report)
+            summary = _refresh_benchmark_evidence(bundle, config.data, benchmark, provenance)
+            report = generate_report(
+                config.name,
+                config.data,
+                summary_path,
+                validation_path,
+                geometry_assets,
+                benchmark,
+                plot_assets,
+                provenance=provenance,
+            )
+            report_path = bundle.write_text("report.md", report)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
+            print(report_path)
+            return 0
+
+        if args.command == "benchmark":
+            docker_status = get_docker_runtime_status() if (args.docker_openmc or openmc is None) else None
+            runtime, error_message = resolve_benchmark_runtime(
+                docker_requested=args.docker_openmc,
+                local_openmc_available=openmc is not None,
+                docker_status=docker_status,
+            )
+            if runtime == "docker":
+                execution = run_solver_backed_benchmark(repo_root, config.name, bundle.run_id)
+                bundle.write_json("benchmark_execution.json", execution)
+            elif runtime == "local":
+                summary = run_case(
+                    config,
+                    bundle,
+                    benchmark=benchmark,
+                    solver_enabled=True,
+                    provenance=provenance,
+                    repo_root=repo_root,
+                )
+                bundle.write_json(
+                    "benchmark_execution.json",
+                    {
+                        "runtime": "local-openmc",
+                        "summary_status": summary.get("neutronics", {}).get("status"),
+                    },
+                )
+            else:
+                raise RuntimeError(error_message or missing_openmc_runtime_message(command_name="benchmark"))
+
+            summary_path = bundle.root / "summary.json"
+            if not summary_path.exists():
+                raise FileNotFoundError(
+                    f"No summary found for benchmark case '{config.name}' in {bundle.root}. "
+                    "The solver-backed benchmark run did not produce a summary bundle."
+                )
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            generate_summary_plots(bundle, summary)
+            validation = validate_case(config, bundle, summary=summary, benchmark=benchmark, provenance=provenance)
+            generate_validation_plot(bundle, validation)
+            geometry_assets = None
+            render_assets_path = bundle.root / "render_assets.json"
+            if render_assets_path.exists():
+                geometry_assets = json.loads(render_assets_path.read_text(encoding="utf-8"))
+            else:
+                build_manifest_path = bundle.root / "build_manifest.json"
+                if build_manifest_path.exists():
+                    build_manifest = json.loads(build_manifest_path.read_text(encoding="utf-8"))
+                    geometry_assets = build_manifest.get("geometry_assets")
+            plot_assets = load_plot_manifest(bundle.root / "plots_manifest.json")
+            summary["artifact_status"] = refresh_bundle_artifact_statuses(bundle, summary=summary)
+            bundle.write_json("summary.json", summary)
+            report = generate_report(
+                config.name,
+                config.data,
+                summary_path,
+                bundle.root / "validation.json",
+                geometry_assets,
+                benchmark,
+                plot_assets,
+                provenance=provenance,
+            )
+            bundle.write_text("report.md", report)
+            summary = _refresh_benchmark_evidence(bundle, config.data, benchmark, provenance)
+            report = generate_report(
+                config.name,
+                config.data,
+                bundle.root / "summary.json",
+                bundle.root / "validation.json",
+                geometry_assets,
+                benchmark,
+                plot_assets,
+                provenance=provenance,
+            )
+            bundle.write_text("report.md", report)
+            _finish_cli_stage(bundle, args.command, stage_command, stage_started_utc, stage_artifacts_before, provenance, summary=summary, repo_root=repo_root)
+            print(bundle.root)
+            return 0
+
+        if args.command == "verify-bundle":
+            failures = _verify_bundle_evidence_contract(bundle)
+            if failures:
+                for failure in failures:
+                    print(f"FAIL: {failure}", file=sys.stderr)
+                raise SystemExit(1)
+            print(f"Bundle evidence contract OK: {bundle.root}")
+            return 0
+
+        return 1
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - record a failed stage then re-raise.
+        try:
+            _finish_cli_stage(
+                bundle,
+                args.command,
+                stage_command,
+                stage_started_utc,
+                stage_artifacts_before,
+                provenance,
+                status="failed",
+                repo_root=repo_root,
+                message=str(exc),
+            )
+        except Exception:  # noqa: BLE001 - never mask the original failure.
+            pass
+        raise
 
 
 def _refresh_benchmark_evidence(
@@ -888,6 +924,43 @@ def _replace_validation_benchmark_quality_checks(
     validation["passed"] = all(check.get("status") == "pass" for check in checks)
     bundle.write_json("validation.json", validation)
 
+def _verify_bundle_evidence_contract(bundle: ResultBundle) -> list[str]:
+    """Return trust-contract failures for a generated bundle (empty means OK).
+
+    Fails closed when sidecars are invalid, presentation QA fails, the summary's
+    embedded artifact status is stale relative to the canonical sidecar, or the
+    report overclaims solver-backed/benchmark-ready/build-candidate status.
+    """
+    failures: list[str] = []
+    failures.extend(validate_bundle_sidecars(bundle.root))
+
+    summary_path = bundle.root / "summary.json"
+    summary: dict[str, object] = {}
+    if summary_path.exists():
+        try:
+            loaded = json.loads(summary_path.read_text(encoding="utf-8"))
+            summary = loaded if isinstance(loaded, dict) else {}
+        except JSONDecodeError:
+            failures.append("summary.json is not valid JSON.")
+
+    embedded = summary.get("artifact_status")
+    canonical = load_canonical_artifact_status(bundle.root, {})
+    if isinstance(embedded, dict) and canonical and embedded != canonical:
+        failures.append("summary.json artifact_status is stale relative to artifact_status.json.")
+
+    report_path = bundle.root / "report.md"
+    if report_path.exists():
+        qa = build_presentation_qa(bundle.root, report_text=report_path.read_text(encoding="utf-8"))
+        for check in qa.get("checks", []):
+            if check.get("status") != "pass":
+                failures.append(f"presentation QA check failed: {check.get('name')} ({check.get('detail', '')})")
+
+    evidence = build_evidence_status(bundle.root, summary)
+    if evidence["blockers"] and evidence["claim_tier"] == "solver_backed":
+        failures.append("evidence gate reports solver-backed claim tier while blockers remain.")
+    return failures
+
+
 def _load_or_create_bundle(repo_root: Path, case_name: str, run_id: str | None, *, allow_existing: bool = False) -> ResultBundle:
     if run_id is None:
         return create_result_bundle(repo_root, case_name)
@@ -931,9 +1004,11 @@ def _finish_cli_stage(
     summary: dict[str, object] | None = None,
     status: str | None = None,
     repo_root: Path | None = None,
+    message: str | None = None,
 ) -> None:
+    summary = summary if isinstance(summary, dict) else {}
+    _persist_refreshed_artifact_status(bundle, summary)
     after = snapshot_bundle_artifacts(bundle)
-    summary = summary or {}
     stage_repo_root = repo_root or _repo_root_from_bundle(bundle)
     append_stage_manifest(
         bundle,
@@ -946,7 +1021,36 @@ def _finish_cli_stage(
         output_artifacts=sorted(changed_bundle_artifacts(artifacts_before, after)),
         method_tier=_method_tier_from_summary(summary),
         repo_root=stage_repo_root,
+        message=message,
     )
+
+
+def _persist_refreshed_artifact_status(bundle: ResultBundle, summary: dict[str, object]) -> dict[str, object]:
+    """Refresh the canonical artifact-status sidecar and keep summary.json in sync.
+
+    Every CLI stage funnels through here so no branch can leave a stale
+    ``summary["artifact_status"]`` behind a fresher ``artifact_status.json``.
+    """
+    summary_path = bundle.root / "summary.json"
+    status_summary = summary
+    if not status_summary and summary_path.exists():
+        try:
+            loaded = json.loads(summary_path.read_text(encoding="utf-8"))
+        except (OSError, JSONDecodeError):
+            loaded = None
+        if isinstance(loaded, dict):
+            status_summary = loaded
+    artifact_status = refresh_bundle_artifact_statuses(bundle, summary=status_summary)
+    summary["artifact_status"] = artifact_status
+    if summary_path.exists():
+        try:
+            persisted = json.loads(summary_path.read_text(encoding="utf-8"))
+        except (OSError, JSONDecodeError):
+            persisted = None
+        if isinstance(persisted, dict) and persisted.get("artifact_status") != artifact_status:
+            persisted["artifact_status"] = artifact_status
+            bundle.write_json("summary.json", persisted)
+    return artifact_status
 
 
 def _repo_root_from_bundle(bundle: ResultBundle) -> Path | None:

--- a/src/thorium_reactor/evidence.py
+++ b/src/thorium_reactor/evidence.py
@@ -1,0 +1,154 @@
+"""Shared compiled evidence gate for claim-tier decisions.
+
+Reporting, design readiness, reactor classification, and presentation QA all
+answer the same questions: is the bundle solver-backed, can it use
+benchmark-ready language, and can it use commercial/build-candidate language?
+This module compiles a single evidence object from the canonical bundle
+sidecars so those decisions stay consistent and fail closed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+EVIDENCE_STATUS_SCHEMA_VERSION = 1
+
+_SOLVER_BACKED_STATES = {"completed"}
+
+
+def load_canonical_artifact_status(bundle_dir: Path | None, summary: dict[str, Any]) -> dict[str, Any]:
+    """Return artifact status, preferring the canonical sidecar over summary.
+
+    ``artifact_status.json`` is the source of truth: later commands refresh the
+    sidecar without necessarily rewriting ``summary.json``, so an embedded
+    ``summary["artifact_status"]`` may be stale.
+    """
+    if bundle_dir is not None:
+        sidecar = Path(bundle_dir) / "artifact_status.json"
+        if sidecar.exists():
+            try:
+                payload = json.loads(sidecar.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                payload = None
+            if isinstance(payload, dict):
+                return payload
+    embedded = summary.get("artifact_status")
+    return embedded if isinstance(embedded, dict) else {}
+
+
+def build_evidence_status(bundle_dir: Path | None, summary: dict[str, Any]) -> dict[str, Any]:
+    """Compile the fail-closed evidence object for claim-tier decisions."""
+    summary = summary if isinstance(summary, dict) else {}
+    artifact_status = load_canonical_artifact_status(bundle_dir, summary)
+    groups = artifact_status.get("groups", {}) if isinstance(artifact_status.get("groups"), dict) else {}
+    openmc_group = groups.get("openmc", {}) if isinstance(groups.get("openmc"), dict) else {}
+    openmc_state = str(openmc_group.get("state", "")).lower() or "unknown"
+
+    statepoints = _statepoint_artifacts(bundle_dir, openmc_group)
+    neutronics = summary.get("neutronics", {}) if isinstance(summary.get("neutronics"), dict) else {}
+    neutronics_status = str(neutronics.get("status", "")).lower() or "unknown"
+
+    blockers: list[str] = []
+    if neutronics_status != "completed":
+        blockers.append(f"Neutronics status is '{neutronics_status}', not a completed solver run.")
+    if openmc_state not in _SOLVER_BACKED_STATES:
+        blockers.append(f"OpenMC artifact state is '{openmc_state}', not 'completed'.")
+    if not statepoints:
+        blockers.append("No solver-backed OpenMC statepoint artifact is present.")
+
+    can_use_solver_backed_language = not blockers
+
+    benchmark_quality = summary.get("benchmark_quality", {}) if isinstance(summary.get("benchmark_quality"), dict) else {}
+    benchmark_evidence = _load_benchmark_evidence(bundle_dir, summary)
+    benchmark_blockers: list[str] = []
+    if benchmark_quality.get("benchmark_ready") is not True:
+        benchmark_blockers.append("Benchmark quality gates are not ready.")
+    if benchmark_evidence:
+        if int(benchmark_evidence.get("failed_gate_count", 0) or 0) > 0:
+            benchmark_blockers.append("Benchmark evidence contract has failed gates.")
+        if benchmark_evidence.get("benchmark_ready_evidence") is False:
+            benchmark_blockers.append("Benchmark evidence contract is not benchmark-ready.")
+    can_use_benchmark_ready_language = can_use_solver_backed_language and not benchmark_blockers
+
+    failed_stages = _failed_stages(bundle_dir)
+    design_readiness = summary.get("design_readiness", {}) if isinstance(summary.get("design_readiness"), dict) else {}
+    severe_finding_count = int(design_readiness.get("severe_finding_count", 0) or 0)
+    build_blockers: list[str] = []
+    if severe_finding_count > 0:
+        build_blockers.append(f"{severe_finding_count} severe design-screening finding(s) remain.")
+    if failed_stages:
+        build_blockers.append(f"Stage manifest records failed stage(s): {', '.join(sorted(failed_stages))}.")
+    can_use_build_candidate_language = can_use_benchmark_ready_language and not build_blockers
+
+    all_blockers = blockers + benchmark_blockers + build_blockers
+    return {
+        "schema_version": EVIDENCE_STATUS_SCHEMA_VERSION,
+        "openmc_artifact_state": openmc_state,
+        "neutronics_status": neutronics_status,
+        "statepoint_artifacts": sorted(statepoints),
+        "has_solver_backed_statepoint": bool(statepoints) and openmc_state in _SOLVER_BACKED_STATES,
+        "claim_tier": "solver_backed" if can_use_solver_backed_language else "reduced_order_or_proxy",
+        "can_use_solver_backed_language": can_use_solver_backed_language,
+        "can_use_benchmark_ready_language": can_use_benchmark_ready_language,
+        "can_use_build_candidate_language": can_use_build_candidate_language,
+        "severe_finding_count": severe_finding_count,
+        "failed_stages": sorted(failed_stages),
+        "blockers": all_blockers,
+    }
+
+
+def _statepoint_artifacts(bundle_dir: Path | None, openmc_group: dict[str, Any]) -> list[str]:
+    if bundle_dir is not None:
+        openmc_dir = Path(bundle_dir) / "openmc"
+        if openmc_dir.exists():
+            return [
+                str(path.relative_to(openmc_dir)).replace("\\", "/")
+                for path in openmc_dir.rglob("statepoint.*")
+                if path.is_file() and path.suffix == ".h5"
+            ]
+        return []
+    artifacts = openmc_group.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return []
+    return [
+        str(name)
+        for name in artifacts
+        if Path(str(name)).name.startswith("statepoint.") and str(name).endswith(".h5")
+    ]
+
+
+def _load_benchmark_evidence(bundle_dir: Path | None, summary: dict[str, Any]) -> dict[str, Any]:
+    evidence = summary.get("benchmark_evidence")
+    if isinstance(evidence, dict) and evidence:
+        return evidence
+    if bundle_dir is None:
+        return {}
+    path = Path(bundle_dir) / "benchmark_evidence.json"
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _failed_stages(bundle_dir: Path | None) -> list[str]:
+    if bundle_dir is None:
+        return []
+    path = Path(bundle_dir) / "stage_manifest.json"
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    stages = payload.get("stages", []) if isinstance(payload, dict) else []
+    failed = []
+    for stage in stages:
+        if isinstance(stage, dict) and str(stage.get("status", "")).lower() == "failed":
+            failed.append(str(stage.get("stage", "unknown")))
+    return failed

--- a/src/thorium_reactor/integrations.py
+++ b/src/thorium_reactor/integrations.py
@@ -57,12 +57,13 @@ def run_named_integration(
     benchmark: dict[str, Any] | None = None,
     provenance: dict[str, Any] | None = None,
     execute: bool = False,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     definition = _integration_definition(name)
     built = build_case(config, bundle.openmc_dir, benchmark=benchmark)
-    summary = _ensure_summary(config, bundle, benchmark=benchmark, provenance=provenance)
+    summary = _ensure_summary(config, bundle, benchmark=benchmark, provenance=provenance, repo_root=repo_root)
     settings = _integration_settings(config, name)
-    runtime_context = build_runtime_context(command=[name, config.name])
+    runtime_context = build_runtime_context(command=[name, config.name], cwd=repo_root)
     input_path = bundle.root / definition["input_name"]
     handoff_path = bundle.root / definition["handoff_name"]
     rendered_input = _render_integration_input(name, config, summary, built.manifest, built.geometry_description, settings)
@@ -121,6 +122,7 @@ def run_moose_integration(
     benchmark: dict[str, Any] | None = None,
     provenance: dict[str, Any] | None = None,
     execute: bool = False,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     return run_named_integration(
         "moose",
@@ -129,6 +131,7 @@ def run_moose_integration(
         benchmark=benchmark,
         provenance=provenance,
         execute=execute,
+        repo_root=repo_root,
     )
 
 
@@ -139,6 +142,7 @@ def run_scale_integration(
     benchmark: dict[str, Any] | None = None,
     provenance: dict[str, Any] | None = None,
     execute: bool = False,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     return run_named_integration(
         "scale",
@@ -147,6 +151,7 @@ def run_scale_integration(
         benchmark=benchmark,
         provenance=provenance,
         execute=execute,
+        repo_root=repo_root,
     )
 
 
@@ -157,6 +162,7 @@ def run_thermochimica_integration(
     benchmark: dict[str, Any] | None = None,
     provenance: dict[str, Any] | None = None,
     execute: bool = False,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     return run_named_integration(
         "thermochimica",
@@ -165,6 +171,7 @@ def run_thermochimica_integration(
         benchmark=benchmark,
         provenance=provenance,
         execute=execute,
+        repo_root=repo_root,
     )
 
 
@@ -175,6 +182,7 @@ def run_saltproc_integration(
     benchmark: dict[str, Any] | None = None,
     provenance: dict[str, Any] | None = None,
     execute: bool = False,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     return run_named_integration(
         "saltproc",
@@ -183,6 +191,7 @@ def run_saltproc_integration(
         benchmark=benchmark,
         provenance=provenance,
         execute=execute,
+        repo_root=repo_root,
     )
 
 
@@ -193,6 +202,7 @@ def run_moltres_integration(
     benchmark: dict[str, Any] | None = None,
     provenance: dict[str, Any] | None = None,
     execute: bool = False,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     return run_named_integration(
         "moltres",
@@ -201,6 +211,7 @@ def run_moltres_integration(
         benchmark=benchmark,
         provenance=provenance,
         execute=execute,
+        repo_root=repo_root,
     )
 
 
@@ -217,6 +228,7 @@ def _ensure_summary(
     *,
     benchmark: dict[str, Any] | None,
     provenance: dict[str, Any] | None,
+    repo_root: Path | None = None,
 ) -> dict[str, Any]:
     summary_path = bundle.root / "summary.json"
     if summary_path.exists():
@@ -227,6 +239,7 @@ def _ensure_summary(
         benchmark=benchmark,
         solver_enabled=False,
         provenance=provenance,
+        repo_root=repo_root,
     )
 
 

--- a/src/thorium_reactor/paths.py
+++ b/src/thorium_reactor/paths.py
@@ -224,10 +224,12 @@ def latest_result_bundle(repo_root: Path, case_name: str) -> ResultBundle:
     case_root = repo_root / "results" / resolved_case_name
     if not case_root.exists():
         raise FileNotFoundError(f"No results found for case '{resolved_case_name}'.")
-    candidates = sorted([path for path in case_root.iterdir() if path.is_dir()])
+    candidates = [path for path in case_root.iterdir() if path.is_dir()]
     if not candidates:
         raise FileNotFoundError(f"No runs found for case '{resolved_case_name}'.")
-    latest = candidates[-1]
+    # Newest by modification time so arbitrary run-id formats (web-*, CI ids)
+    # never outrank a newer timestamped run; ties fall back to the name.
+    latest = max(candidates, key=lambda path: (path.stat().st_mtime, path.name))
     return ResultBundle(
         case_name=resolved_case_name,
         run_id=latest.name,

--- a/src/thorium_reactor/reporting/reports.py
+++ b/src/thorium_reactor/reporting/reports.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from typing import Any
 
 from thorium_reactor.benchmarking import assess_benchmark_traceability
+from thorium_reactor.evidence import build_evidence_status
 from thorium_reactor.reporting.plots import load_figure_catalog
+from thorium_reactor.sidecar_schemas import validate_bundle_sidecars
 
 
 def generate_report(
@@ -25,7 +27,9 @@ def generate_report(
 ) -> str:
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     artifact_status_path = summary_path.parent / "artifact_status.json"
-    if "artifact_status" not in summary and artifact_status_path.exists():
+    if artifact_status_path.exists():
+        # The sidecar is canonical: later commands refresh it without always
+        # rewriting summary.json, so an embedded copy may be stale.
         try:
             summary["artifact_status"] = json.loads(artifact_status_path.read_text(encoding="utf-8"))
         except JSONDecodeError:
@@ -1623,6 +1627,7 @@ def build_presentation_qa(bundle_dir: Path, report_text: str | None = None) -> d
     _qa_figure_manifest(checks, bundle_dir)
     _qa_dry_run_warning(checks, bundle_dir, report_text)
     _qa_status_contradictions(checks, bundle_dir, report_text)
+    _qa_sidecar_schemas(checks, bundle_dir)
     passed = all(check["status"] == "pass" for check in checks)
     return {"passed": passed, "checks": checks}
 
@@ -1710,16 +1715,32 @@ def _qa_dry_run_warning(checks: list[dict[str, Any]], bundle_dir: Path, report_t
 
 def _qa_status_contradictions(checks: list[dict[str, Any]], bundle_dir: Path, report_text: str) -> None:
     summary = _read_json(bundle_dir / "summary.json")
-    status = str(summary.get("neutronics", {}).get("status", "")).lower() if isinstance(summary, dict) else ""
+    evidence = build_evidence_status(bundle_dir, summary)
     contradictions = []
-    if status and status != "completed" and "solver-backed OpenMC result" in report_text and "not a solver-backed OpenMC physics result" not in report_text:
-        contradictions.append("dry-run report claims solver-backed evidence")
-    artifact_status = summary.get("artifact_status", {}) if isinstance(summary, dict) else {}
-    groups = artifact_status.get("groups", {}) if isinstance(artifact_status, dict) else {}
-    openmc = groups.get("openmc", {}) if isinstance(groups, dict) else {}
-    if isinstance(openmc, dict) and openmc.get("state") in {"missing", "dry_run"} and "Build candidate: `true`" in report_text:
-        contradictions.append("build candidate true with missing/dry-run OpenMC artifacts")
+    claims_solver_backed = (
+        "solver-backed OpenMC result" in report_text
+        and "not a solver-backed OpenMC physics result" not in report_text
+        and "no solver-backed OpenMC result" not in report_text
+    )
+    claims_build_candidate = "Build candidate: `true`" in report_text or "Build candidate: `True`" in report_text
+    claims_benchmark_ready = "Benchmark ready: `true`" in report_text or "Benchmark ready: `True`" in report_text
+    if claims_solver_backed and not evidence["can_use_solver_backed_language"]:
+        contradictions.append("report claims solver-backed evidence without a completed statepoint-backed OpenMC artifact state")
+    if claims_build_candidate and not evidence["can_use_build_candidate_language"]:
+        contradictions.append("build candidate true while evidence gates block build-candidate language")
+    if claims_benchmark_ready and not evidence["can_use_benchmark_ready_language"]:
+        contradictions.append("benchmark-ready true while benchmark evidence gates are blocked")
+    if evidence["failed_stages"] and (claims_build_candidate or claims_benchmark_ready):
+        contradictions.append(
+            "failed stage(s) recorded in stage_manifest.json contradict completed-result claims: "
+            + ", ".join(evidence["failed_stages"])
+        )
     checks.append(_qa_check("report::status_contradictions", not contradictions, "; ".join(contradictions)))
+
+
+def _qa_sidecar_schemas(checks: list[dict[str, Any]], bundle_dir: Path) -> None:
+    errors = validate_bundle_sidecars(bundle_dir)
+    checks.append(_qa_check("sidecars::schema_valid", not errors, "; ".join(errors[:5])))
 
 
 def _qa_check(name: str, passed: bool, detail: str = "") -> dict[str, Any]:
@@ -2233,7 +2254,10 @@ def _neutronics_status(summary: dict[str, Any]) -> str:
 
 
 def _is_solver_backed_neutronics(summary: dict[str, Any]) -> bool:
-    return _neutronics_status(summary).lower() == "completed"
+    # Fail closed through the shared evidence gate: a completed neutronics
+    # status alone is not solver-backed evidence without a statepoint-backed
+    # OpenMC artifact state.
+    return bool(build_evidence_status(None, summary)["can_use_solver_backed_language"])
 
 
 def _humanize_label(name: str) -> str:
@@ -2384,11 +2408,11 @@ def _classify_reactor_case(
     stage = str(reactor.get("stage", "")).lower()
     summary = summary or {}
     benchmark_quality = benchmark_quality or {}
-    solver_backed = _is_solver_backed_neutronics(summary)
-    benchmark_ready = benchmark_quality.get("benchmark_ready") is True if benchmark_quality else False
+    evidence = build_evidence_status(None, summary)
+    solver_backed = evidence["can_use_solver_backed_language"]
+    benchmark_ready = evidence["can_use_benchmark_ready_language"] and benchmark_quality.get("benchmark_ready") is True
     evidence_limited = not solver_backed or not benchmark_ready
-    design_readiness = summary.get("design_readiness", {}) if isinstance(summary.get("design_readiness"), dict) else {}
-    severe_screening = int(design_readiness.get("severe_finding_count", 0) or 0) > 0
+    severe_screening = evidence["severe_finding_count"] > 0
     if case_name == "example_pin":
         return {
             "role": "smoke/regression pin",

--- a/src/thorium_reactor/sidecar_schemas.py
+++ b/src/thorium_reactor/sidecar_schemas.py
@@ -1,0 +1,181 @@
+"""Lightweight fail-closed schema validation for machine-readable sidecars.
+
+Bundles carry provenance, artifact status, stage manifests, readiness, claims,
+and figure metadata as JSON sidecars. These validators catch corrupted or
+structurally invalid payloads before reports or QA make decisions from them.
+Errors always identify the artifact path and the offending field.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_ARTIFACT_STATUS_VERSIONS = {1}
+SUPPORTED_STAGE_MANIFEST_VERSIONS = {1}
+SUPPORTED_PROVENANCE_VERSIONS = {1}
+SUPPORTED_FIGURE_CATALOG_VERSIONS = {1, 2}
+
+
+class SidecarValidationError(ValueError):
+    def __init__(self, artifact: str, field: str, message: str) -> None:
+        self.artifact = artifact
+        self.field = field
+        super().__init__(f"{artifact}: field '{field}' {message}")
+
+
+def validate_artifact_status(payload: Any, *, artifact: str = "artifact_status.json") -> dict[str, Any]:
+    data = _require_mapping(payload, artifact, "<root>")
+    _require_version(data, artifact, SUPPORTED_ARTIFACT_STATUS_VERSIONS)
+    for field in ("case_name", "run_id", "updated_utc"):
+        _require_str(data, artifact, field)
+    groups = _require_mapping(data.get("groups"), artifact, "groups")
+    for name, group in groups.items():
+        group_map = _require_mapping(group, artifact, f"groups.{name}")
+        _require_str(group_map, artifact, f"groups.{name}.state", value=group_map.get("state"))
+        if not isinstance(group_map.get("artifacts"), list):
+            raise SidecarValidationError(artifact, f"groups.{name}.artifacts", "must be a list")
+        for field in ("blockers", "warnings"):
+            if not isinstance(group_map.get(field, []), list):
+                raise SidecarValidationError(artifact, f"groups.{name}.{field}", "must be a list")
+    for field in ("blockers", "warnings"):
+        if field in data and not isinstance(data[field], list):
+            raise SidecarValidationError(artifact, field, "must be a list")
+    return data
+
+
+def validate_stage_manifest(payload: Any, *, artifact: str = "stage_manifest.json") -> dict[str, Any]:
+    data = _require_mapping(payload, artifact, "<root>")
+    _require_version(data, artifact, SUPPORTED_STAGE_MANIFEST_VERSIONS)
+    for field in ("case_name", "run_id"):
+        _require_str(data, artifact, field)
+    stages = data.get("stages")
+    if not isinstance(stages, list):
+        raise SidecarValidationError(artifact, "stages", "must be a list")
+    for index, stage in enumerate(stages):
+        stage_map = _require_mapping(stage, artifact, f"stages[{index}]")
+        for field in ("stage", "status", "started_utc", "ended_utc"):
+            _require_str(stage_map, artifact, f"stages[{index}].{field}", value=stage_map.get(field))
+        if not isinstance(stage_map.get("sequence"), int):
+            raise SidecarValidationError(artifact, f"stages[{index}].sequence", "must be an integer")
+        if not isinstance(stage_map.get("command"), list):
+            raise SidecarValidationError(artifact, f"stages[{index}].command", "must be a list")
+        if not isinstance(stage_map.get("output_artifacts", []), list):
+            raise SidecarValidationError(artifact, f"stages[{index}].output_artifacts", "must be a list")
+    return data
+
+
+def validate_provenance(payload: Any, *, artifact: str = "provenance.json") -> dict[str, Any]:
+    data = _require_mapping(payload, artifact, "<root>")
+    _require_version(data, artifact, SUPPORTED_PROVENANCE_VERSIONS)
+    for field in ("case_name", "run_id", "created_utc"):
+        _require_str(data, artifact, field)
+    # input_snapshots / git / runtime are optional for legacy bundles but must
+    # be mappings when present.
+    for field in ("input_snapshots", "git", "runtime"):
+        if field in data and data[field] is not None and not isinstance(data[field], dict):
+            raise SidecarValidationError(artifact, field, "must be a mapping when present")
+    return data
+
+
+def validate_design_readiness(payload: Any, *, artifact: str = "design_readiness.json") -> dict[str, Any]:
+    data = _require_mapping(payload, artifact, "<root>")
+    _require_str(data, artifact, "status")
+    if not isinstance(data.get("severe_finding_count"), int):
+        raise SidecarValidationError(artifact, "severe_finding_count", "must be an integer")
+    findings = data.get("findings")
+    if not isinstance(findings, list):
+        raise SidecarValidationError(artifact, "findings", "must be a list")
+    for index, finding in enumerate(findings):
+        finding_map = _require_mapping(finding, artifact, f"findings[{index}]")
+        for field in ("metric", "severity", "basis", "evidence_artifact"):
+            _require_str(finding_map, artifact, f"findings[{index}].{field}", value=finding_map.get(field))
+    if not isinstance(data.get("commercial_or_build_candidate_language_allowed"), bool):
+        raise SidecarValidationError(artifact, "commercial_or_build_candidate_language_allowed", "must be a boolean")
+    return data
+
+
+def validate_result_claims(payload: Any, *, artifact: str = "result_claims.json") -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise SidecarValidationError(artifact, "<root>", "must be a list of claims")
+    for index, claim in enumerate(payload):
+        claim_map = _require_mapping(claim, artifact, f"[{index}]")
+        for field in ("claim", "status", "evidence_artifact", "evidence_tier"):
+            _require_str(claim_map, artifact, f"[{index}].{field}", value=claim_map.get(field))
+    return payload
+
+
+def validate_figure_catalog(payload: Any, *, artifact: str = "plots_manifest.json") -> dict[str, Any]:
+    data = _require_mapping(payload, artifact, "<root>")
+    version = data.get("schema_version")
+    figures = data.get("figures")
+    if version is None and figures is None:
+        # Legacy flat {plot_id: path} manifests remain readable.
+        for plot_id, value in data.items():
+            if not isinstance(value, str):
+                raise SidecarValidationError(artifact, str(plot_id), "legacy manifest entries must be path strings")
+        return data
+    if version not in SUPPORTED_FIGURE_CATALOG_VERSIONS:
+        raise SidecarValidationError(artifact, "schema_version", f"unsupported version {version!r}")
+    figures_map = _require_mapping(figures, artifact, "figures")
+    for plot_id, entry in figures_map.items():
+        entry_map = _require_mapping(entry, artifact, f"figures.{plot_id}")
+        for field in ("path", "title", "caption", "quality_status", "status"):
+            _require_str(entry_map, artifact, f"figures.{plot_id}.{field}", value=entry_map.get(field))
+    return data
+
+
+_SIDECAR_VALIDATORS = {
+    "artifact_status.json": validate_artifact_status,
+    "stage_manifest.json": validate_stage_manifest,
+    "provenance.json": validate_provenance,
+    "design_readiness.json": validate_design_readiness,
+    "result_claims.json": validate_result_claims,
+    "plots_manifest.json": validate_figure_catalog,
+}
+
+
+def validate_bundle_sidecars(bundle_dir: Path) -> list[str]:
+    """Validate every recognized sidecar present in a bundle.
+
+    Returns a list of human-readable errors; an empty list means every present
+    sidecar parsed and validated. Missing sidecars are not errors here - the
+    evidence gate and QA decide what absence means.
+    """
+    errors: list[str] = []
+    for name, validator in _SIDECAR_VALIDATORS.items():
+        path = Path(bundle_dir) / name
+        if not path.exists():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{name}: not readable as JSON ({exc}).")
+            continue
+        try:
+            validator(payload, artifact=name)
+        except SidecarValidationError as exc:
+            errors.append(str(exc))
+    return errors
+
+
+def _require_mapping(value: Any, artifact: str, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SidecarValidationError(artifact, field, "must be a mapping")
+    return value
+
+
+def _require_str(data: dict[str, Any], artifact: str, field: str, *, value: Any = None) -> str:
+    resolved = value if value is not None else data.get(field.split(".")[-1])
+    if not isinstance(resolved, str) or not resolved:
+        raise SidecarValidationError(artifact, field, "must be a non-empty string")
+    return resolved
+
+
+def _require_version(data: dict[str, Any], artifact: str, supported: set[int]) -> int:
+    version = data.get("schema_version")
+    if version not in supported:
+        raise SidecarValidationError(artifact, "schema_version", f"unsupported version {version!r}")
+    return version

--- a/src/thorium_reactor/web/app.py
+++ b/src/thorium_reactor/web/app.py
@@ -109,18 +109,17 @@ def create_app(repo_root: Path | None = None) -> FastAPI:
     @app.get("/api/runs/{case_name}/{run_id}/events")
     async def stream_events(case_name: str, run_id: str) -> StreamingResponse:
         async def event_stream():
-            seen = 0
+            offset = 0
             while True:
                 try:
-                    events = repository.read_events(case_name, run_id)
-                    record = repository.get_run(case_name, run_id)
+                    events, offset = repository.read_events_from(case_name, run_id, offset)
+                    status = repository.run_status(case_name, run_id)
                 except FileNotFoundError:
                     yield "event: error\ndata: {\"message\":\"Run not found\"}\n\n"
                     return
-                for event in events[seen:]:
+                for event in events:
                     yield f"event: run\ndata: {json.dumps(model_to_dict(event))}\n\n"
-                seen = len(events)
-                if is_terminal(record.status):
+                if is_terminal(status):
                     return
                 await asyncio.sleep(1.0)
 
@@ -170,6 +169,8 @@ def create_app(repo_root: Path | None = None) -> FastAPI:
 
         @app.get("/{full_path:path}", include_in_schema=False)
         def serve_spa(full_path: str) -> FileResponse:
+            if full_path == "api" or full_path.startswith("api/"):
+                raise HTTPException(status_code=404, detail="API route not found.")
             candidate = (dist_dir / full_path).resolve()
             if candidate.is_file() and candidate.is_relative_to(dist_dir.resolve()):
                 return FileResponse(candidate)

--- a/src/thorium_reactor/web/jobs.py
+++ b/src/thorium_reactor/web/jobs.py
@@ -187,14 +187,25 @@ def write_status(run_dir: Path, payload: dict[str, Any]) -> None:
     write_json(run_dir / "job_status.json", payload)
 
 
+_SEQUENCE_LOCK = threading.Lock()
+_SEQUENCE_CACHE: dict[Path, int] = {}
+
+
 def append_event(run_dir: Path, level: str, phase: str | None, message: str, *, progress: float | None = None) -> RunEvent:
     path = run_dir / "job_events.ndjson"
-    sequence = 1
-    if path.exists():
-        sequence = len(path.read_text(encoding="utf-8").splitlines()) + 1
-    event = RunEvent(sequence=sequence, timestamp=utc_now(), level=level, phase=phase, message=message, progress=progress)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(model_to_dict(event), sort_keys=True) + "\n")
+    with _SEQUENCE_LOCK:
+        sequence = _SEQUENCE_CACHE.get(path)
+        if sequence is None:
+            # First append for this run in this process: count once, then cache.
+            sequence = 0
+            if path.exists():
+                with path.open("rb") as handle:
+                    sequence = sum(1 for _ in handle)
+        sequence += 1
+        _SEQUENCE_CACHE[path] = sequence
+        event = RunEvent(sequence=sequence, timestamp=utc_now(), level=level, phase=phase, message=message, progress=progress)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(model_to_dict(event), sort_keys=True) + "\n")
     return event
 
 

--- a/src/thorium_reactor/web/permissions.py
+++ b/src/thorium_reactor/web/permissions.py
@@ -1,28 +1,32 @@
 from __future__ import annotations
 
+import contextlib
+import hmac
+import ipaddress
 import json
 import os
 import threading
+import time as time_module
 from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import HTTPException, Request
 
 from thorium_reactor.web.schemas import AuthSession, RateLimitRecord
 
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
 
 OWNER_EMAIL = "seamusdgallagher@gmail.com"
 LOCAL_DEV_EMAIL = OWNER_EMAIL
-LOCAL_HOSTNAMES = {"localhost", "127.0.0.1", "::1"}
-ACCESS_EMAIL_HEADERS = (
-    "cf-access-authenticated-user-email",
-    "x-authenticated-user-email",
-    "x-forwarded-email",
-    "x-user-email",
-)
+ACCESS_IDENTITY_HEADER = "cf-access-authenticated-user-email"
+PROXY_SECRET_HEADER = "x-thorium-proxy-secret"
 
 
 @dataclass(frozen=True)
@@ -37,15 +41,49 @@ class AccessController:
         self.admin_emails = configured_admin_emails()
         self.daily_limit = configured_daily_limit()
         self.access_required = truthy(os.environ.get("THORIUM_REACTOR_ACCESS_REQUIRED"))
+        self.proxy_secret = configured_proxy_secret()
+        self.trusted_client_networks = configured_trusted_client_networks()
         self.store = RateLimitStore(repo_root, daily_limit=self.daily_limit)
 
     def user_from_request(self, request: Request) -> AccessUser:
-        email = email_from_headers(request)
+        email = self.verified_email_from_headers(request)
         if email is None:
-            if self.access_required and not is_localhost_request(request):
-                raise HTTPException(status_code=401, detail="Cloudflare Access identity is required to start simulations.")
+            if self.access_required and not self.is_trusted_local_transport(request):
+                raise HTTPException(
+                    status_code=401,
+                    detail="A verified access identity is required to use this deployment.",
+                )
             email = normalize_email(os.environ.get("THORIUM_REACTOR_LOCAL_DEV_EMAIL", LOCAL_DEV_EMAIL))
         return AccessUser(email=email, is_admin=email in self.admin_emails)
+
+    def verified_email_from_headers(self, request: Request) -> str | None:
+        raw = request.headers.get(ACCESS_IDENTITY_HEADER)
+        if not raw:
+            return None
+        if not self.access_required:
+            # Development convenience only: without the access requirement the
+            # deployment is already treated as a trusted local lab.
+            return normalize_email(raw)
+        if self.proxy_secret is None:
+            # Fail closed: without a proxy shared secret there is no way to
+            # prove the identity header came from the trusted access proxy.
+            return None
+        presented = request.headers.get(PROXY_SECRET_HEADER, "")
+        if not hmac.compare_digest(presented.encode("utf-8"), self.proxy_secret.encode("utf-8")):
+            return None
+        return normalize_email(raw)
+
+    def is_trusted_local_transport(self, request: Request) -> bool:
+        client = request.client
+        if client is None or not client.host:
+            return False
+        try:
+            address = ipaddress.ip_address(client.host)
+        except ValueError:
+            return False
+        if address.is_loopback:
+            return True
+        return any(address in network for network in self.trusted_client_networks)
 
     def session_for(self, user: AccessUser) -> AuthSession:
         record = self.store.record_for(user.email)
@@ -84,12 +122,12 @@ class RateLimitStore:
         self._lock = threading.Lock()
 
     def record_for(self, email: str) -> RateLimitRecord:
-        with self._lock:
+        with self._exclusive():
             data = self._read()
             return self._record_from_payload(email, data.get("users", {}).get(email, {}))
 
     def claim(self, email: str) -> RateLimitRecord:
-        with self._lock:
+        with self._exclusive():
             data = self._read()
             users = data.setdefault("users", {})
             record = self._record_from_payload(email, users.get(email, {}))
@@ -113,7 +151,7 @@ class RateLimitStore:
             return self._record_from_payload(email, payload)
 
     def release(self, email: str) -> None:
-        with self._lock:
+        with self._exclusive():
             data = self._read()
             users = data.setdefault("users", {})
             record = self._record_from_payload(email, users.get(email, {}))
@@ -124,7 +162,7 @@ class RateLimitStore:
 
     def reset(self, email: str, *, reset_by: str) -> RateLimitRecord:
         normalized = normalize_email(email)
-        with self._lock:
+        with self._exclusive():
             data = self._read()
             users = data.setdefault("users", {})
             payload = {
@@ -143,10 +181,23 @@ class RateLimitStore:
             return self._record_from_payload(normalized, payload)
 
     def list_records(self) -> list[RateLimitRecord]:
-        with self._lock:
+        with self._exclusive():
             data = self._read()
             records = [self._record_from_payload(email, payload) for email, payload in data.get("users", {}).items()]
         return sorted(records, key=lambda record: record.email)
+
+    @contextlib.contextmanager
+    def _exclusive(self) -> Iterator[None]:
+        """Serialize read-modify-write cycles across threads and processes."""
+        with self._lock:
+            lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            with lock_path.open("a+b") as handle:
+                _lock_file_exclusive(handle)
+                try:
+                    yield
+                finally:
+                    _unlock_file(handle)
 
     def _record_from_payload(self, email: str, payload: dict[str, Any]) -> RateLimitRecord:
         date_key = self._date_key()
@@ -187,18 +238,25 @@ class RateLimitStore:
         temp_path.replace(self.path)
 
 
-def email_from_headers(request: Request) -> str | None:
-    for header in ACCESS_EMAIL_HEADERS:
-        value = request.headers.get(header)
-        if value:
-            return normalize_email(value)
-    return None
+def _lock_file_exclusive(handle: Any) -> None:
+    if os.name == "nt":
+        while True:
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                time_module.sleep(0.01)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
 
 
-def is_localhost_request(request: Request) -> bool:
-    host = request.headers.get("host", "")
-    hostname = host.rsplit(":", 1)[0].strip("[]").lower()
-    return hostname in LOCAL_HOSTNAMES
+def _unlock_file(handle: Any) -> None:
+    if os.name == "nt":
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def configured_admin_emails() -> set[str]:
@@ -217,6 +275,27 @@ def configured_daily_limit() -> int:
         return max(int(raw), 1)
     except ValueError:
         return 1
+
+
+def configured_proxy_secret() -> str | None:
+    raw = os.environ.get("THORIUM_REACTOR_PROXY_SHARED_SECRET", "").strip()
+    return raw or None
+
+
+def configured_trusted_client_networks() -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    raw = os.environ.get("THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS", "")
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for value in raw.replace(";", ",").split(","):
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(value, strict=False))
+        except ValueError as exc:
+            raise ValueError(
+                f"THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS entry '{value}' is not a valid IP address or CIDR network."
+            ) from exc
+    return networks
 
 
 def configured_store_path(repo_root: Path) -> Path:

--- a/src/thorium_reactor/web/repository.py
+++ b/src/thorium_reactor/web/repository.py
@@ -170,18 +170,47 @@ class WebRepository:
         return self._run_record(case_name, run_id, run_dir)
 
     def read_events(self, case_name: str, run_id: str) -> list[RunEvent]:
+        events, _offset = self.read_events_from(case_name, run_id, 0)
+        return events
+
+    def read_events_from(self, case_name: str, run_id: str, offset: int = 0) -> tuple[list[RunEvent], int]:
+        """Read events appended at or after the given byte offset.
+
+        Returns the newly parsed events and the byte offset to resume from, so
+        pollers only pay for new data instead of re-parsing the whole log.
+        """
         path = self._run_dir(case_name, run_id) / "job_events.ndjson"
         if not path.exists():
-            return []
+            return [], offset
         events: list[RunEvent] = []
-        for line in path.read_text(encoding="utf-8").splitlines():
+        with path.open("rb") as handle:
+            handle.seek(offset)
+            chunk = handle.read()
+            new_offset = offset + len(chunk)
+        text = chunk.decode("utf-8", errors="replace")
+        trailing = 0
+        if text and not text.endswith("\n"):
+            # A writer may be mid-append; leave the partial line for next poll.
+            partial = text.rsplit("\n", 1)[-1]
+            trailing = len(partial.encode("utf-8"))
+            text = text[: len(text) - len(partial)]
+        for line in text.splitlines():
             if not line.strip():
                 continue
             try:
                 events.append(RunEvent(**json.loads(line)))
             except json.JSONDecodeError:
                 continue
-        return events
+        return events, new_offset - trailing
+
+    def run_status(self, case_name: str, run_id: str) -> str:
+        """Resolve the run status without building a full RunRecord."""
+        run_dir = self._run_dir(case_name, run_id)
+        if not run_dir.exists():
+            raise FileNotFoundError(f"Run '{run_id}' for case '{case_name}' was not found.")
+        status_payload = read_json(run_dir / "job_status.json", {})
+        status = status_payload.get("status") if isinstance(status_payload, Mapping) else None
+        return str(status) if status else infer_status_from_files(run_dir)
 
     def list_docs(self) -> list[DocSummary]:
         docs: list[DocSummary] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,6 +234,88 @@ def test_cli_stage_manifest_records_modified_existing_artifact(tmp_path: Path) -
     assert "summary.json" in manifest["stages"][0]["output_artifacts"]
 
 
+def test_finish_cli_stage_syncs_summary_with_refreshed_sidecar(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "example_pin", "stale-summary")
+    # Summary embeds a stale artifact_status claiming the folder was never generated.
+    bundle.write_json(
+        "summary.json",
+        {
+            "neutronics": {"status": "completed"},
+            "artifact_status": {"groups": {"openmc": {"state": "not_generated", "artifacts": []}}},
+        },
+    )
+    (bundle.openmc_dir / "statepoint.42.h5").write_bytes(b"\x89HDF\r\n\x1a\n")
+    before = snapshot_bundle_artifacts(bundle)
+
+    _finish_cli_stage(
+        bundle,
+        "render",
+        ["render", "example_pin"],
+        "2026-07-14T00:00:00Z",
+        before,
+        {"input_snapshots": {}},
+        summary={"neutronics": {"status": "completed"}},
+        repo_root=tmp_path,
+    )
+
+    sidecar = json.loads((bundle.root / "artifact_status.json").read_text(encoding="utf-8"))
+    summary = json.loads((bundle.root / "summary.json").read_text(encoding="utf-8"))
+    assert sidecar["groups"]["openmc"]["state"] == "completed"
+    # summary.json must be re-synced with the fresh sidecar, not left stale.
+    assert summary["artifact_status"]["groups"]["openmc"]["state"] == "completed"
+
+
+def test_cli_records_failed_stage_when_command_raises(tmp_path: Path) -> None:
+    scratch = tmp_path / "repo"
+    (scratch / "configs" / "cases" / "example_pin").mkdir(parents=True)
+    (scratch / "benchmarks" / "tmsr_lf1").mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "configs" / "cases" / "example_pin" / "case.yaml", scratch / "configs" / "cases" / "example_pin" / "case.yaml")
+    shutil.copy2(REPO_ROOT / "benchmarks" / "tmsr_lf1" / "benchmark.yaml", scratch / "benchmarks" / "tmsr_lf1" / "benchmark.yaml")
+
+    # report on a bundle with no summary.json raises FileNotFoundError.
+    create_result_bundle(scratch, "example_pin", "no-summary")
+    with pytest.raises(FileNotFoundError):
+        main(["--repo-root", str(scratch), "report", "example_pin", "--run-id", "no-summary"])
+
+    manifest = json.loads((scratch / "results" / "example_pin" / "no-summary" / "stage_manifest.json").read_text(encoding="utf-8"))
+    failed = [stage for stage in manifest["stages"] if stage["status"] == "failed"]
+    assert failed and failed[-1]["stage"] == "report"
+    assert failed[-1].get("message")
+
+
+def test_cli_verify_bundle_passes_for_dry_run_report(tmp_path: Path) -> None:
+    scratch = tmp_path / "repo"
+    (scratch / "configs" / "cases" / "example_pin").mkdir(parents=True)
+    (scratch / "benchmarks" / "tmsr_lf1").mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "configs" / "cases" / "example_pin" / "case.yaml", scratch / "configs" / "cases" / "example_pin" / "case.yaml")
+    shutil.copy2(REPO_ROOT / "benchmarks" / "tmsr_lf1" / "benchmark.yaml", scratch / "benchmarks" / "tmsr_lf1" / "benchmark.yaml")
+
+    assert main(["--repo-root", str(scratch), "run", "example_pin", "--run-id", "vb", "--no-solver"]) == 0
+    assert main(["--repo-root", str(scratch), "report", "example_pin", "--run-id", "vb"]) == 0
+    assert main(["--repo-root", str(scratch), "verify-bundle", "example_pin", "--run-id", "vb"]) == 0
+
+
+def test_cli_verify_bundle_fails_on_stale_summary_status(tmp_path: Path) -> None:
+    scratch = tmp_path / "repo"
+    (scratch / "configs" / "cases" / "example_pin").mkdir(parents=True)
+    (scratch / "benchmarks" / "tmsr_lf1").mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "configs" / "cases" / "example_pin" / "case.yaml", scratch / "configs" / "cases" / "example_pin" / "case.yaml")
+    shutil.copy2(REPO_ROOT / "benchmarks" / "tmsr_lf1" / "benchmark.yaml", scratch / "benchmarks" / "tmsr_lf1" / "benchmark.yaml")
+
+    assert main(["--repo-root", str(scratch), "run", "example_pin", "--run-id", "vb", "--no-solver"]) == 0
+    assert main(["--repo-root", str(scratch), "report", "example_pin", "--run-id", "vb"]) == 0
+
+    # Corrupt summary.json's embedded artifact_status so it disagrees with the sidecar.
+    bundle_root = scratch / "results" / "example_pin" / "vb"
+    summary = json.loads((bundle_root / "summary.json").read_text(encoding="utf-8"))
+    summary["artifact_status"] = {"groups": {"openmc": {"state": "completed", "artifacts": ["statepoint.fake.h5"]}}}
+    (bundle_root / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--repo-root", str(scratch), "verify-bundle", "example_pin", "--run-id", "vb"])
+    assert exc.value.code == 1
+
+
 def test_stage_command_from_sys_argv_preserves_subcommand_options(monkeypatch) -> None:
     monkeypatch.setattr(
         sys,

--- a/tests/test_evidence_contract.py
+++ b/tests/test_evidence_contract.py
@@ -1,0 +1,184 @@
+"""Adversarial regression fixtures for the evidence/readiness trust contract.
+
+These prove the repo refuses to overclaim solver-backed, benchmark-ready, or
+build-candidate status when evidence is stale, missing, failed, or contradictory.
+Fixtures are small and deterministic (no solver-backed OpenMC runs).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from thorium_reactor.evidence import build_evidence_status, load_canonical_artifact_status
+from thorium_reactor.paths import create_result_bundle, refresh_bundle_artifact_statuses
+from thorium_reactor.reporting.reports import build_presentation_qa
+from thorium_reactor.sidecar_schemas import (
+    SidecarValidationError,
+    validate_artifact_status,
+    validate_bundle_sidecars,
+    validate_stage_manifest,
+)
+
+
+def _write(path: Path, payload) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def test_completed_status_without_statepoint_is_not_solver_backed(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "no-statepoint")
+    summary = {"neutronics": {"status": "completed"}}
+    refresh_bundle_artifact_statuses(bundle, summary=summary)
+
+    evidence = build_evidence_status(bundle.root, summary)
+
+    assert evidence["has_solver_backed_statepoint"] is False
+    assert evidence["can_use_solver_backed_language"] is False
+    assert any("statepoint" in blocker.lower() for blocker in evidence["blockers"])
+
+
+def test_completed_status_with_statepoint_is_solver_backed(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "with-statepoint")
+    (bundle.openmc_dir / "statepoint.100.h5").write_bytes(b"\x89HDF\r\n\x1a\n")
+    summary = {"neutronics": {"status": "completed"}}
+    refresh_bundle_artifact_statuses(bundle, summary=summary)
+
+    evidence = build_evidence_status(bundle.root, summary)
+
+    assert evidence["has_solver_backed_statepoint"] is True
+    assert evidence["can_use_solver_backed_language"] is True
+    assert not any("statepoint" in blocker.lower() for blocker in evidence["blockers"])
+
+
+def test_stale_embedded_artifact_status_is_ignored_for_fresh_sidecar(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "stale-embedded")
+    (bundle.openmc_dir / "statepoint.50.h5").write_bytes(b"\x89HDF\r\n\x1a\n")
+    refresh_bundle_artifact_statuses(bundle, summary={"neutronics": {"status": "completed"}})
+    summary = {
+        "neutronics": {"status": "completed"},
+        # Stale copy claims the folder was never generated.
+        "artifact_status": {"groups": {"openmc": {"state": "not_generated", "artifacts": []}}},
+    }
+
+    canonical = load_canonical_artifact_status(bundle.root, summary)
+    assert canonical["groups"]["openmc"]["state"] == "completed"
+
+    evidence = build_evidence_status(bundle.root, summary)
+    assert evidence["can_use_solver_backed_language"] is True
+
+
+def test_failed_state_blocks_solver_backed_language(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "failed-openmc")
+    # No statepoint and a completed status forces the sidecar to a failed state.
+    (bundle.openmc_dir / "openmc_error.log").write_text("solver crashed", encoding="utf-8")
+    summary = {"neutronics": {"status": "completed"}}
+    status = refresh_bundle_artifact_statuses(bundle, summary=summary)
+
+    assert status["groups"]["openmc"]["state"] in {"failed", "skipped"}
+    assert build_evidence_status(bundle.root, summary)["can_use_solver_backed_language"] is False
+
+
+def test_report_build_candidate_true_with_dry_run_evidence_fails_qa(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "build-candidate-dryrun")
+    summary = {"neutronics": {"status": "dry-run"}}
+    _write(bundle.root / "summary.json", summary)
+    refresh_bundle_artifact_statuses(bundle, summary=summary)
+    report_text = (
+        "## Reactor Classification\n\n- Build candidate: `true`\n\n"
+        "## Results Generated In This Run\n\n- `summary.json`\n\n"
+        "## Validation And Blockers\n\n- none\n\n## Interpretation\n\n- x\n\n"
+        "## Limitations\n\n- x\n\n## Future Work / Novelty Tracks\n\n- x\n\n"
+        "## Evidence Sources\n\n- x\n\n"
+    )
+
+    qa = build_presentation_qa(bundle.root, report_text=report_text)
+
+    failed = {check["name"] for check in qa["checks"] if check["status"] == "fail"}
+    assert "report::status_contradictions" in failed
+    assert qa["passed"] is False
+
+
+@pytest.mark.parametrize("bad_state", ["failed", "skipped", "not_generated"])
+def test_qa_flags_build_candidate_against_any_non_completed_openmc_state(tmp_path: Path, bad_state: str) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", f"state-{bad_state}")
+    summary = {"neutronics": {"status": "dry-run"}}
+    _write(bundle.root / "summary.json", summary)
+    status = refresh_bundle_artifact_statuses(bundle, summary=summary)
+    status["groups"]["openmc"]["state"] = bad_state
+    _write(bundle.root / "artifact_status.json", status)
+    report_text = (
+        "## Reactor Classification\n\n- Build candidate: `true`\n\n"
+        "## Results Generated In This Run\n\n- `summary.json`\n\n"
+        "## Validation And Blockers\n\n- none\n\n## Interpretation\n\n- x\n\n"
+        "## Limitations\n\n- x\n\n## Future Work / Novelty Tracks\n\n- x\n\n"
+        "## Evidence Sources\n\n- x\n\n"
+    )
+
+    qa = build_presentation_qa(bundle.root, report_text=report_text)
+
+    failed = {check["name"] for check in qa["checks"] if check["status"] == "fail"}
+    assert "report::status_contradictions" in failed
+
+
+def test_failed_stage_manifest_contradicts_benchmark_ready_claim(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "failed-stage")
+    (bundle.openmc_dir / "statepoint.10.h5").write_bytes(b"\x89HDF\r\n\x1a\n")
+    summary = {"neutronics": {"status": "completed"}, "benchmark_quality": {"benchmark_ready": True}}
+    _write(bundle.root / "summary.json", summary)
+    refresh_bundle_artifact_statuses(bundle, summary=summary)
+    _write(
+        bundle.root / "stage_manifest.json",
+        {
+            "schema_version": 1,
+            "case_name": "adv_case",
+            "run_id": "failed-stage",
+            "stages": [
+                {
+                    "sequence": 1,
+                    "stage": "report",
+                    "status": "failed",
+                    "started_utc": "2026-07-14T00:00:00Z",
+                    "ended_utc": "2026-07-14T00:00:01Z",
+                    "command": ["report"],
+                }
+            ],
+        },
+    )
+
+    evidence = build_evidence_status(bundle.root, summary)
+
+    assert evidence["failed_stages"] == ["report"]
+    assert evidence["can_use_build_candidate_language"] is False
+
+
+def test_corrupted_sidecar_is_reported_by_schema_validation(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "corrupt-sidecar")
+    (bundle.root / "artifact_status.json").write_text("{not valid json", encoding="utf-8")
+
+    errors = validate_bundle_sidecars(bundle.root)
+
+    assert any("artifact_status.json" in error for error in errors)
+
+
+def test_partial_sidecar_missing_required_field_fails_validation() -> None:
+    with pytest.raises(SidecarValidationError) as exc:
+        validate_artifact_status({"schema_version": 1, "case_name": "c", "run_id": "r"})
+    assert exc.value.field in {"updated_utc", "groups"}
+
+    with pytest.raises(SidecarValidationError):
+        validate_stage_manifest({"schema_version": 99, "case_name": "c", "run_id": "r", "stages": []})
+
+
+def test_rerun_on_existing_bundle_refreshes_sidecar(tmp_path: Path) -> None:
+    bundle = create_result_bundle(tmp_path, "adv_case", "rerun")
+    first = refresh_bundle_artifact_statuses(bundle, summary={"neutronics": {"status": "dry-run"}})
+    assert first["groups"]["openmc"]["state"] == "dry_run"
+
+    # A later stage adds a statepoint; the refreshed sidecar must reflect it.
+    (bundle.openmc_dir / "statepoint.5.h5").write_bytes(b"\x89HDF\r\n\x1a\n")
+    second = refresh_bundle_artifact_statuses(bundle, summary={"neutronics": {"status": "completed"}})
+    assert second["groups"]["openmc"]["state"] == "completed"
+    on_disk = json.loads((bundle.root / "artifact_status.json").read_text(encoding="utf-8"))
+    assert on_disk["groups"]["openmc"]["state"] == "completed"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import json
+import os
+import time
 
 import pytest
 
@@ -7,9 +9,25 @@ from thorium_reactor.paths import (
     append_stage_manifest,
     changed_bundle_artifacts,
     create_result_bundle,
+    latest_result_bundle,
     refresh_bundle_artifact_statuses,
     snapshot_bundle_artifacts,
 )
+
+
+def test_latest_result_bundle_prefers_newest_run_regardless_of_run_id_format(tmp_path: Path) -> None:
+    old = create_result_bundle(tmp_path, "layout_case", "20260101-000000-000001-aaaaaaaa")
+    web = create_result_bundle(tmp_path, "layout_case", "web-demo")
+    newest = create_result_bundle(tmp_path, "layout_case", "20260102-000000-000001-bbbbbbbb")
+
+    base = time.time()
+    os.utime(old.root, (base - 300, base - 300))
+    os.utime(web.root, (base - 200, base - 200))
+    os.utime(newest.root, (base - 100, base - 100))
+    assert latest_result_bundle(tmp_path, "layout_case").run_id == newest.run_id
+
+    os.utime(web.root, (base, base))
+    assert latest_result_bundle(tmp_path, "layout_case").run_id == "web-demo"
 
 def test_result_bundle_creates_dedicated_geometry_exports_dir(tmp_path: Path) -> None:
     repo_root = tmp_path / "bundle-layout-test"

--- a/tests/test_precursors.py
+++ b/tests/test_precursors.py
@@ -92,3 +92,160 @@ def test_loop_segment_precursor_state_reports_external_segment_sources() -> None
 
     assert updated_summary["loop_segment_count"] == 3
     assert updated_summary["total_inventory"] > 0.0
+
+
+# --- Advection/decay verification (issue #17) ---------------------------------
+#
+# The two-region model integrates, by backward Euler,
+#   dC_core/dt = S - (1/tau_core + lambda) C_core + (1/tau_loop) C_loop
+#   dC_loop/dt = (1/tau_core) C_core - (1/tau_loop + lambda + k) C_loop
+# where S is the source, lambda the decay constant, tau the residence times,
+# and k the cleanup rate. The tests below are manufactured-solution checks of
+# conservation, decay, residence time, and flow edge cases.
+
+
+def _single_group(decay_constant_s: float) -> list:
+    return normalize_precursor_groups([{"name": "g", "decay_constant_s": decay_constant_s, "yield_fraction": 1.0}])
+
+
+def test_precursor_inventory_is_conserved_without_decay_or_cleanup() -> None:
+    # With lambda -> 0, cleanup = 0, and no source, total core+loop inventory is
+    # a conserved quantity; transport only redistributes it between regions.
+    groups = _single_group(1.0e-9)
+    state = build_initial_precursor_state(
+        groups=groups,
+        core_residence_time_s=1.0,
+        loop_residence_time_s=6.0,
+        cleanup_rate_s=0.0,
+        transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+    )
+    initial_total = summarize_precursor_state(state, groups)["total_inventory"]
+
+    for _ in range(20):
+        state = step_precursor_state(
+            state=state,
+            groups=groups,
+            power_fraction=0.0,  # no source
+            flow_fraction=1.0,
+            dt_s=0.5,
+            core_residence_time_s=1.0,
+            loop_residence_time_s=6.0,
+            cleanup_rate_s=0.0,
+            transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+        )
+    final_total = summarize_precursor_state(state, groups)["total_inventory"]
+
+    assert final_total == pytest.approx(initial_total, rel=1.0e-4)
+
+
+def test_precursor_decay_reduces_inventory_faster_for_larger_constant() -> None:
+    # Source removed (power=0): the group with the larger decay constant must
+    # lose inventory faster, isolating the decay term.
+    def _decayed_total(decay_constant_s: float) -> float:
+        groups = _single_group(decay_constant_s)
+        state = build_initial_precursor_state(
+            groups=groups,
+            core_residence_time_s=1.0,
+            loop_residence_time_s=6.0,
+            cleanup_rate_s=0.0,
+            transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+        )
+        start = summarize_precursor_state(state, groups)["total_inventory"]
+        for _ in range(10):
+            state = step_precursor_state(
+                state=state,
+                groups=groups,
+                power_fraction=0.0,
+                flow_fraction=1.0,
+                dt_s=0.5,
+                core_residence_time_s=1.0,
+                loop_residence_time_s=6.0,
+                cleanup_rate_s=0.0,
+                transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+            )
+        return summarize_precursor_state(state, groups)["total_inventory"] / start
+
+    slow_retained = _decayed_total(0.02)
+    fast_retained = _decayed_total(0.5)
+
+    assert 0.0 < fast_retained < slow_retained < 1.0
+
+
+def test_precursor_steady_state_is_a_fixed_point_under_matched_stepping() -> None:
+    # Stepping the steady state at the conditions it was built for must leave the
+    # inventory essentially unchanged: the source exactly balances decay+transport.
+    groups = normalize_precursor_groups(None)
+    params = dict(core_residence_time_s=1.5, loop_residence_time_s=7.0, cleanup_rate_s=0.0)
+    state = build_initial_precursor_state(groups=groups, transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL, **params)
+    before = summarize_precursor_state(state, groups)["total_inventory"]
+
+    stepped = step_precursor_state(
+        state=state,
+        groups=groups,
+        power_fraction=1.0,
+        flow_fraction=1.0,
+        dt_s=1.0,
+        transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+        **params,
+    )
+    after = summarize_precursor_state(stepped, groups)["total_inventory"]
+
+    assert after == pytest.approx(before, rel=1.0e-6)
+
+
+def test_precursor_lower_flow_retains_more_delayed_source_in_core() -> None:
+    # Advection edge case: reducing the flow fraction lengthens residence times,
+    # so fewer precursors are swept into the loop and the transport loss falls.
+    groups = normalize_precursor_groups(None)
+    params = dict(core_residence_time_s=1.0, loop_residence_time_s=6.0, cleanup_rate_s=0.0)
+
+    def _loss_at_flow(flow_fraction: float) -> float:
+        state = build_initial_precursor_state(groups=groups, transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL, **params)
+        stepped = step_precursor_state(
+            state=state,
+            groups=groups,
+            power_fraction=1.0,
+            flow_fraction=flow_fraction,
+            dt_s=2.0,
+            transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+            **params,
+        )
+        return summarize_precursor_state(stepped, groups)["precursor_transport_loss_fraction"]
+
+    assert _loss_at_flow(0.1) < _loss_at_flow(1.0)
+
+
+def test_precursor_longer_loop_residence_increases_transport_loss() -> None:
+    # Residence-time check: a longer external-loop residence time leaves more
+    # delayed-neutron source stranded outside the core at steady state.
+    groups = normalize_precursor_groups(None)
+
+    def _loss_for_loop(loop_residence_time_s: float) -> float:
+        state = build_initial_precursor_state(
+            groups=groups,
+            core_residence_time_s=1.0,
+            loop_residence_time_s=loop_residence_time_s,
+            cleanup_rate_s=0.0,
+            transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+        )
+        return summarize_precursor_state(state, groups)["precursor_transport_loss_fraction"]
+
+    assert _loss_for_loop(3.0) < _loss_for_loop(12.0)
+
+
+def test_precursor_cleanup_removes_loop_inventory() -> None:
+    # Cleanup acts only on the loop region: enabling it must lower total steady
+    # inventory versus the no-cleanup baseline, isolating the source-sink term.
+    groups = normalize_precursor_groups(None)
+
+    def _total_for_cleanup(cleanup_rate_s: float) -> float:
+        state = build_initial_precursor_state(
+            groups=groups,
+            core_residence_time_s=1.0,
+            loop_residence_time_s=6.0,
+            cleanup_rate_s=cleanup_rate_s,
+            transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+        )
+        return summarize_precursor_state(state, groups)["total_inventory"]
+
+    assert _total_for_cleanup(1.0e-2) < _total_for_cleanup(0.0)

--- a/tests/test_web_backend.py
+++ b/tests/test_web_backend.py
@@ -1,4 +1,9 @@
+import json
+import os
 import shutil
+import subprocess
+import sys
+import textwrap
 import time
 import uuid
 from pathlib import Path
@@ -7,6 +12,8 @@ from fastapi.testclient import TestClient
 
 from thorium_reactor.paths import create_result_bundle
 from thorium_reactor.web.app import create_app
+from thorium_reactor.web.jobs import append_event
+from thorium_reactor.web.repository import WebRepository
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -349,15 +356,180 @@ def test_web_requires_access_identity_when_configured(monkeypatch) -> None:
     assert response.status_code == 401
 
 
-def test_web_allows_localhost_dev_identity_when_access_is_required(monkeypatch) -> None:
+def test_web_allows_loopback_transport_dev_identity_when_access_is_required(monkeypatch) -> None:
     monkeypatch.setenv("THORIUM_REACTOR_ACCESS_REQUIRED", "1")
-    client = TestClient(create_app(REPO_ROOT), base_url="http://127.0.0.1:18488")
+    client = TestClient(create_app(REPO_ROOT), client=("127.0.0.1", 50123))
 
     response = client.get("/api/me")
 
     assert response.status_code == 200
     assert response.json()["email"] == "seamusdgallagher@gmail.com"
     assert response.json()["is_admin"] is True
+
+
+def test_web_rejects_spoofed_identity_headers_when_access_is_required(monkeypatch) -> None:
+    monkeypatch.setenv("THORIUM_REACTOR_ACCESS_REQUIRED", "1")
+    client = TestClient(create_app(REPO_ROOT), client=("203.0.113.10", 4242))
+
+    for header in ("x-user-email", "x-forwarded-email", "x-authenticated-user-email"):
+        response = client.get("/api/me", headers={header: "seamusdgallagher@gmail.com"})
+        assert response.status_code == 401, header
+
+    unverified = client.get(
+        "/api/me",
+        headers={"cf-access-authenticated-user-email": "seamusdgallagher@gmail.com"},
+    )
+    assert unverified.status_code == 401
+
+    admin_probe = client.get(
+        "/api/admin/rate-limits",
+        headers={"x-user-email": "seamusdgallagher@gmail.com"},
+    )
+    assert admin_probe.status_code == 401
+
+
+def test_web_rejects_host_header_localhost_spoof_when_access_is_required(monkeypatch) -> None:
+    monkeypatch.setenv("THORIUM_REACTOR_ACCESS_REQUIRED", "1")
+    client = TestClient(
+        create_app(REPO_ROOT),
+        base_url="http://localhost:18488",
+        client=("203.0.113.10", 4242),
+    )
+
+    response = client.get("/api/me")
+
+    assert response.status_code == 401
+
+
+def test_web_trusts_identity_header_only_with_proxy_shared_secret(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("THORIUM_REACTOR_ACCESS_REQUIRED", "1")
+    monkeypatch.setenv("THORIUM_REACTOR_PROXY_SHARED_SECRET", "tunnel-secret")
+    monkeypatch.setenv("THORIUM_REACTOR_RATE_LIMIT_PATH", str(tmp_path / "limits.json"))
+    client = TestClient(create_app(REPO_ROOT), client=("203.0.113.10", 4242))
+    identity = {"cf-access-authenticated-user-email": "guest@example.com"}
+
+    wrong_secret = client.get("/api/me", headers={**identity, "x-thorium-proxy-secret": "wrong"})
+    assert wrong_secret.status_code == 401
+
+    verified = client.get("/api/me", headers={**identity, "x-thorium-proxy-secret": "tunnel-secret"})
+    assert verified.status_code == 200
+    assert verified.json()["email"] == "guest@example.com"
+    assert verified.json()["is_admin"] is False
+
+
+def test_web_trusted_client_addrs_extend_local_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("THORIUM_REACTOR_ACCESS_REQUIRED", "1")
+    monkeypatch.setenv("THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS", "172.18.0.0/16")
+    client = TestClient(create_app(REPO_ROOT), client=("172.18.0.1", 39100))
+
+    response = client.get("/api/me")
+
+    assert response.status_code == 200
+    assert response.json()["email"] == "seamusdgallagher@gmail.com"
+
+
+def test_web_unknown_api_route_returns_json_404() -> None:
+    client = TestClient(create_app(REPO_ROOT))
+
+    response = client.get("/api/does-not-exist")
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_web_spa_deep_links_serve_index_but_api_routes_404(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+    (repo_root / "configs" / "cases").mkdir(parents=True)
+    dist = repo_root / "web" / "ui" / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<html>spa-shell</html>", encoding="utf-8")
+    client = TestClient(create_app(repo_root))
+
+    deep_link = client.get("/runs/example_pin/some-run")
+    assert deep_link.status_code == 200
+    assert "spa-shell" in deep_link.text
+
+    api_missing = client.get("/api/runz")
+    assert api_missing.status_code == 404
+    assert api_missing.headers["content-type"].startswith("application/json")
+
+
+def test_rate_limit_store_is_safe_across_processes(tmp_path: Path) -> None:
+    store_path = tmp_path / "limits.json"
+    worker = tmp_path / "claim_worker.py"
+    worker.write_text(
+        textwrap.dedent(
+            f"""
+            import sys
+            from pathlib import Path
+
+            sys.path.insert(0, {str(REPO_ROOT / "src")!r})
+
+            from fastapi import HTTPException
+
+            from thorium_reactor.web.permissions import RateLimitStore
+
+            store = RateLimitStore(Path({str(REPO_ROOT)!r}), daily_limit=5)
+            successes = 0
+            for _ in range(25):
+                try:
+                    store.claim("guest@example.com")
+                    successes += 1
+                except HTTPException:
+                    pass
+            print(successes)
+            """
+        ),
+        encoding="utf-8",
+    )
+    env = dict(os.environ, THORIUM_REACTOR_RATE_LIMIT_PATH=str(store_path))
+    processes = [
+        subprocess.Popen([sys.executable, str(worker)], env=env, stdout=subprocess.PIPE, text=True)
+        for _ in range(4)
+    ]
+    totals = []
+    for process in processes:
+        out, _err = process.communicate(timeout=180)
+        assert process.returncode == 0
+        totals.append(int(out.strip()))
+
+    assert sum(totals) == 5
+    payload = json.loads(store_path.read_text(encoding="utf-8"))
+    assert payload["users"]["guest@example.com"]["count"] == 5
+
+
+def test_append_event_sequences_without_rereading_log(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    for expected in (1, 2, 3):
+        assert append_event(run_dir, "info", None, f"event {expected}").sequence == expected
+
+    # Truncate the log: the cached counter must keep the sequence monotonic,
+    # proving appends no longer re-read the file each time.
+    (run_dir / "job_events.ndjson").write_text("", encoding="utf-8")
+    assert append_event(run_dir, "info", None, "event 4").sequence == 4
+
+
+def test_read_events_from_returns_only_new_events(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+    (repo_root / "configs" / "cases").mkdir(parents=True)
+    run_dir = repo_root / "results" / "example_case" / "run-1"
+    run_dir.mkdir(parents=True)
+    repository = WebRepository(repo_root)
+
+    append_event(run_dir, "info", None, "first")
+    append_event(run_dir, "info", None, "second")
+    events, offset = repository.read_events_from("example_case", "run-1", 0)
+    assert [event.message for event in events] == ["first", "second"]
+
+    append_event(run_dir, "info", None, "third")
+    new_events, new_offset = repository.read_events_from("example_case", "run-1", offset)
+    assert [event.message for event in new_events] == ["third"]
+    assert new_offset > offset
+    assert [event.sequence for event in events + new_events] == [1, 2, 3]
 
 
 def test_web_rate_limits_non_admins_and_admin_can_reset(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_workflow_capabilities.py
+++ b/tests/test_workflow_capabilities.py
@@ -348,6 +348,37 @@ def test_external_integration_commands_export_inputs_and_update_summary() -> Non
         shutil.rmtree(scratch_root, ignore_errors=True)
 
 
+def test_integration_runtime_provenance_uses_explicit_repo_root(monkeypatch) -> None:
+    import thorium_reactor.integrations as integrations
+
+    scratch_root = REPO_ROOT / ".tmp" / "test-integration-repo-root" / uuid.uuid4().hex
+    case_dir = scratch_root / "configs" / "cases" / "immersed_pool_reference"
+    benchmark_dir = scratch_root / "benchmarks" / "tmsr_lf1"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    benchmark_dir.mkdir(parents=True, exist_ok=True)
+    captured: list[Path | None] = []
+
+    real_build_runtime_context = integrations.build_runtime_context
+
+    def _spy(*, command=None, cwd=None):
+        captured.append(cwd)
+        return real_build_runtime_context(command=command, cwd=cwd)
+
+    monkeypatch.setattr(integrations, "build_runtime_context", _spy)
+    try:
+        shutil.copy2(REPO_ROOT / "configs" / "cases" / "immersed_pool_reference" / "case.yaml", case_dir / "case.yaml")
+        shutil.copy2(REPO_ROOT / "benchmarks" / "tmsr_lf1" / "benchmark.yaml", benchmark_dir / "benchmark.yaml")
+
+        exit_code = main(["--repo-root", str(scratch_root), "thermochimica", "immersed_pool_reference", "--run-id", "repo-root"])
+        assert exit_code == 0
+
+        # The integration must describe the target repo, not the process cwd.
+        assert captured, "build_runtime_context was never called"
+        assert all(cwd == scratch_root.resolve() for cwd in captured), captured
+    finally:
+        shutil.rmtree(scratch_root, ignore_errors=True)
+
+
 def test_render_command_uses_existing_run_state_and_emits_visual_assets() -> None:
     scratch_root = REPO_ROOT / ".tmp" / "test-render-command" / uuid.uuid4().hex
     case_dir = scratch_root / "configs" / "cases" / "immersed_pool_reference"

--- a/web/README.md
+++ b/web/README.md
@@ -73,13 +73,23 @@ The deployed Docker service can require Cloudflare Access identity:
 
 | Variable | Meaning |
 | --- | --- |
-| `THORIUM_REACTOR_ACCESS_REQUIRED` | When `1`, run starts require an authenticated Access email header |
+| `THORIUM_REACTOR_ACCESS_REQUIRED` | When `1`, requests need a verified Access identity or a trusted local transport |
+| `THORIUM_REACTOR_PROXY_SHARED_SECRET` | Shared secret the access proxy must send as `x-thorium-proxy-secret` before the identity header is trusted |
+| `THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS` | Extra transport peers (IPs/CIDRs) allowed to use the anonymous local-dev fallback; loopback is always trusted |
 | `THORIUM_REACTOR_ADMIN_EMAILS` | Comma-separated emails with unlimited starts and Admin view access |
 | `THORIUM_REACTOR_RATE_LIMIT_PER_DAY` | Non-admin daily run-start limit |
 | `THORIUM_REACTOR_RATE_LIMIT_TIMEZONE` | Day boundary for rate limits |
 | `THORIUM_REACTOR_RATE_LIMIT_PATH` | Optional path for the rate-limit state JSON |
 
-The local `Run-Web` wrapper disables the Access requirement for development unless `-RequireAccessIdentity` is supplied.
+Identity handling when `THORIUM_REACTOR_ACCESS_REQUIRED=1`:
+
+- Exactly one identity header is honored: `cf-access-authenticated-user-email`.
+- That header is trusted only when `THORIUM_REACTOR_PROXY_SHARED_SECRET` is configured and the request carries the matching `x-thorium-proxy-secret` header (configure the proxy/tunnel to attach it). Without a verified secret, identity headers are ignored and the request fails closed with `401`.
+- The anonymous owner/local-dev fallback is gated on the transport peer address (loopback, plus any `THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS` entries) - never on the spoofable `Host` header.
+
+The local `Run-Web` wrapper disables the Access requirement for development unless `-RequireAccessIdentity` is supplied. When running the compose `web` service directly with access required, browser traffic forwarded from the host arrives from the Docker network gateway, so either use the wrapper for local development or add that gateway to `THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS`.
+
+Rate-limit state is stored in a JSON file guarded by an OS-level file lock, so the daily limit stays correct across multiple workers/processes sharing the same `THORIUM_REACTOR_RATE_LIMIT_PATH`. The default deployment topology remains a single `uvicorn` process.
 
 ## Frontend Development
 


### PR DESCRIPTION
Addresses the actionable web, evidence-contract, and CI issues in a single fail-closed pass. All changes are covered by the local test suite (244 passed, 2 skipped).

## Web (`src/thorium_reactor/web`, `docker-compose.yml`, `web/README.md`)
- **Fixes #79** — Identity is trusted only after a proxy shared-secret check (`x-thorium-proxy-secret` vs `THORIUM_REACTOR_PROXY_SHARED_SECRET`); exactly one identity header (`cf-access-authenticated-user-email`) is honored; the local-dev owner/admin fallback is gated on a trusted transport peer (loopback + `THORIUM_REACTOR_TRUSTED_CLIENT_ADDRS`) instead of the spoofable `Host` header.
- **Fixes #80** — `latest_result_bundle` selects the newest run by mtime, matching the web layer, so `web-`/`msre-` prefixed run ids no longer sort ahead of timestamped runs.
- **Fixes #81** — Run events stream from a byte offset and the append sequence counter is cached, making append/poll cost linear instead of O(n²); status is read from `job_status.json` rather than rebuilding a full `RunRecord` each tick.
- **Fixes #82** — Unknown `/api/*` paths return a JSON 404; non-API deep links still fall through to `index.html`.
- **Fixes #84** — The rate-limit read-modify-write is guarded by an OS file lock so the daily limit is correct across worker processes; documented the topology in `web/README.md`.

## Evidence contract (`evidence.py`, `sidecar_schemas.py`, `reporting/reports.py`, `cli.py`, `integrations.py`)
- **Fixes #61** — New `build_evidence_status` compiles solver-backed / benchmark-ready / build-candidate decisions from the canonical sidecars with explicit blocker reasons; `_is_solver_backed_neutronics`, readiness classification, and reactor classification all route through it.
- **Fixes #60** — Report generation and QA read `artifact_status.json` as canonical rather than a possibly-stale embedded `summary["artifact_status"]`.
- **Fixes #62** — Every CLI stage finalizes through one path that persists the refreshed artifact status back into `summary.json` and records a `failed` stage on exception without masking the error.
- **Fixes #63** — Integration commands and their fallback `run_case` calls forward the explicit `repo_root` to runtime/git provenance.
- **Fixes #64** — Presentation QA fails closed on solver-backed / benchmark-ready / build-candidate overclaims across `failed`, `skipped`, and `not_generated` states and failed stage manifests, via the shared gate.
- **Fixes #65** — Fail-closed schema validators for provenance, stage manifest, artifact status, design readiness, result claims, and figure catalog sidecars; wired into presentation QA.
- **Fixes #66** — `tests/test_evidence_contract.py` adds adversarial fixtures for completed-without-statepoint, stale embedded status, failed/skipped/not_generated states, failed stages, corrupted/partial sidecars, and rerun-on-existing-bundle.

## CI (`.github/workflows/msre-openmc-benchmark.yml`)
- **Fixes #83** — The preflight test/QA/dry-run-report job now runs on pushes to `main` in addition to PRs; the solver-backed benchmark stays `workflow_dispatch`.
- **Fixes #67** — New `reactor verify-bundle` command asserts a bundle's sidecars, presentation QA, and evidence gate agree (fails on stale summary vs sidecar and on overclaims); CI runs the trust-contract test phase and verifies the generated dry-run bundle.

## Verification
- `.runtime-env/python.exe -m pytest tests` → 244 passed, 2 skipped.
- `verify-bundle` smoke-tested end-to-end on a generated dry-run `example_pin` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)