### PR TITLE
Make the GPU sweep path honest, correct, and worth using

### DIFF
--- a/src/thorium_reactor/accelerators.py
+++ b/src/thorium_reactor/accelerators.py
@@ -3,16 +3,64 @@ from __future__ import annotations
 import importlib
 import math
 import os
+import sys
 from dataclasses import dataclass
 from typing import Any
 
 SUPPORTED_ARRAY_BACKENDS = ("python", "numpy", "torch-cpu", "torch-xpu")
 VECTOR_ARRAY_BACKENDS = ("numpy", "torch-cpu", "torch-xpu")
+SUPPORTED_DTYPES = ("float16", "bfloat16", "float32", "float64")
 DEFAULT_DTYPE = "float32"
+REFERENCE_DTYPE = "float64"
+
+# torch.quantile refuses inputs above 2**24 elements; above that we take the
+# explicit sort path instead of discovering the limit through an exception.
+TORCH_QUANTILE_MAX_ELEMENTS = 2**24
 
 
 class BackendUnavailable(RuntimeError):
     pass
+
+
+def configure_torch_environment() -> None:
+    """Install the Intel oneAPI/OpenMP defaults torch needs, before torch loads.
+
+    ``libiomp`` reads ``KMP_DUPLICATE_LIB_OK`` when the DLL is loaded, and the
+    level-zero variables are read when the SYCL runtime initializes. Setting
+    them after ``import torch`` is a no-op, and on Windows the duplicate-OpenMP
+    check then aborts the interpreter outright (``OMP: Error #15``, exit 3)
+    rather than raising something recoverable.
+
+    So these are installed at import time of this module, for every torch
+    device rather than only for XPU -- ``torch-cpu`` loads the same libiomp.
+    Values already present in the environment always win, so an operator can
+    still opt into fallback behaviour deliberately.
+    """
+    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+    os.environ.setdefault("PYTORCH_ENABLE_XPU_FALLBACK", "0")
+    os.environ.setdefault("SYCL_CACHE_PERSISTENT", "1")
+    os.environ.setdefault("ZE_ENABLE_PCI_ID_DEVICE_ORDER", "1")
+
+
+configure_torch_environment()
+
+
+def torch_environment_is_safe() -> tuple[bool, str | None]:
+    """Report whether torch was imported before we could set the OpenMP guard.
+
+    If another module imported torch first, ``configure_torch_environment`` came
+    too late and constructing a torch backend may abort the process. We cannot
+    recover from that abort, so callers surface it as a diagnostic instead.
+    """
+    if "torch" not in sys.modules:
+        return True, None
+    if _truthy_environment(os.environ.get("KMP_DUPLICATE_LIB_OK")):
+        return True, None
+    return False, (
+        "torch was imported before thorium_reactor.accelerators, so KMP_DUPLICATE_LIB_OK "
+        "could not be set in time. Set KMP_DUPLICATE_LIB_OK=TRUE in the environment, or "
+        "import thorium_reactor.accelerators before torch."
+    )
 
 
 def _truthy_environment(value: str | None) -> bool:
@@ -29,6 +77,12 @@ def runtime_environment_report() -> dict[str, Any]:
         "pytorch_xpu_fallback_enabled": _truthy_environment(fallback),
         "KMP_DUPLICATE_LIB_OK": os.environ.get("KMP_DUPLICATE_LIB_OK"),
     }
+
+
+def validate_dtype(dtype: str) -> str:
+    if dtype not in SUPPORTED_DTYPES:
+        raise BackendUnavailable(f"Unsupported array dtype: {dtype!r}. Choose one of {', '.join(SUPPORTED_DTYPES)}.")
+    return dtype
 
 
 @dataclass(frozen=True)
@@ -80,6 +134,15 @@ class ArrayBackend:
     def percentiles(self, value: Any, quantiles: tuple[float, float, float]) -> list[float]:
         raise NotImplementedError
 
+    def percentiles_batch(self, values: list[Any], quantiles: tuple[float, float, float]) -> list[list[float]]:
+        """Percentiles for several arrays with a single host transfer.
+
+        The per-step history reduction needs five percentile triples. Doing them
+        one at a time costs five device synchronizations per time step; batching
+        them costs one.
+        """
+        return [self.percentiles(value, quantiles) for value in values]
+
     def max_scalar(self, value: Any) -> float:
         raise NotImplementedError
 
@@ -98,6 +161,12 @@ class ArrayBackend:
     def memory_allocated_bytes(self) -> int | None:
         return None
 
+    def max_memory_allocated_bytes(self) -> int | None:
+        return None
+
+    def reset_peak_memory_stats(self) -> None:
+        return None
+
     def describe(self) -> dict[str, Any]:
         return {
             "name": self.name,
@@ -107,9 +176,15 @@ class ArrayBackend:
 
 
 class PythonReferenceBackend:
+    """Marker for the pure-Python reference integrator.
+
+    Deliberately not an :class:`ArrayBackend`: the reference integrator works on
+    Python lists and never calls the array contract. It is always float64.
+    """
+
     name = "python"
     device_label = "cpu"
-    dtype_name = "float64"
+    dtype_name = REFERENCE_DTYPE
 
     def describe(self) -> dict[str, Any]:
         return {
@@ -121,18 +196,21 @@ class PythonReferenceBackend:
     def memory_allocated_bytes(self) -> int | None:
         return None
 
+    def max_memory_allocated_bytes(self) -> int | None:
+        return None
+
 
 class NumpyBackend(ArrayBackend):
     def __init__(self, *, dtype_name: str, seed: int) -> None:
         self.xp = importlib.import_module("numpy")
         self.name = "numpy"
         self.device_label = "cpu"
-        self.dtype_name = dtype_name
+        self.dtype_name = validate_dtype(dtype_name)
         self.seed = seed
-        self.dtype = getattr(self.xp, dtype_name)
+        self.dtype = getattr(self.xp, self.dtype_name)
 
     def asarray(self, value: Any, *, dtype: str | None = None) -> Any:
-        resolved_dtype = getattr(self.xp, dtype or self.dtype_name)
+        resolved_dtype = getattr(self.xp, validate_dtype(dtype) if dtype else self.dtype_name)
         return self.xp.asarray(value, dtype=resolved_dtype)
 
     def full(self, shape: tuple[int, ...], value: float) -> Any:
@@ -158,7 +236,7 @@ class NumpyBackend(ArrayBackend):
         return self.xp.sum(value, axis=axis)
 
     def stack(self, values: list[Any], axis: int = 0) -> Any:
-        return self.xp.stack(values, axis=axis)
+        return self.xp.stack([self.xp.asarray(value, dtype=self.dtype) for value in values], axis=axis)
 
     def roll(self, value: Any, *, shift: int, axis: int) -> Any:
         return self.xp.roll(value, shift=shift, axis=axis)
@@ -179,7 +257,12 @@ class NumpyBackend(ArrayBackend):
         return float(value)
 
     def to_host_list(self, value: Any) -> list[float]:
-        raw = value.tolist() if hasattr(value, "tolist") else list(value)
+        # Flattened, matching TorchBackend, so callers can index the result the
+        # same way on either backend.
+        if hasattr(value, "reshape"):
+            raw = self.xp.asarray(value).reshape(-1).tolist()
+        else:
+            raw = value if isinstance(value, list) else [value]
         if isinstance(raw, (int, float)):
             return [float(raw)]
         return [float(item) for item in raw]
@@ -187,55 +270,67 @@ class NumpyBackend(ArrayBackend):
 
 class TorchBackend(ArrayBackend):
     def __init__(self, *, device: str, dtype_name: str, seed: int) -> None:
-        if device == "xpu" and "PYTORCH_ENABLE_XPU_FALLBACK" not in os.environ:
-            os.environ["PYTORCH_ENABLE_XPU_FALLBACK"] = "0"
-        if device == "xpu":
-            os.environ.setdefault("SYCL_CACHE_PERSISTENT", "1")
-            os.environ.setdefault("ZE_ENABLE_PCI_ID_DEVICE_ORDER", "1")
-            os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+        if device not in {"cpu", "xpu"}:
+            raise BackendUnavailable(f"Unsupported torch device: {device}")
+        self.dtype_name = validate_dtype(dtype_name)
+
+        # Must happen before the first torch import in the process; see the
+        # module docstring on configure_torch_environment.
+        configure_torch_environment()
+        safe, message = torch_environment_is_safe()
+        if not safe:
+            raise BackendUnavailable(message or "Unsafe torch import order.")
+
         self.torch = importlib.import_module("torch")
         self.seed = seed
-        self.dtype_name = dtype_name
         self.dtype = {
             "float32": self.torch.float32,
             "float64": self.torch.float64,
             "float16": self.torch.float16,
             "bfloat16": self.torch.bfloat16,
-        }[dtype_name]
+        }[self.dtype_name]
 
         if device == "xpu":
+            self.ipex_import_error: str | None = None
             try:
                 importlib.import_module("intel_extension_for_pytorch")
-            except Exception:
-                pass
+            except ImportError as exc:
+                # Modern torch XPU builds do not need IPEX; record why it was
+                # absent rather than hiding it behind "XPU is not available".
+                self.ipex_import_error = f"{type(exc).__name__}: {exc}"
             if not hasattr(self.torch, "xpu") or not self.torch.xpu.is_available():
-                raise BackendUnavailable("PyTorch XPU is not available.")
+                detail = f" (intel_extension_for_pytorch: {self.ipex_import_error})" if self.ipex_import_error else ""
+                raise BackendUnavailable(f"PyTorch XPU is not available.{detail}")
             self.device = self.torch.device("xpu")
             self.name = "torch-xpu"
             try:
                 self.device_label = self.torch.xpu.get_device_name(0)
             except Exception:
                 self.device_label = "xpu"
-        elif device == "cpu":
+        else:
             self.device = self.torch.device("cpu")
             self.name = "torch-cpu"
             self.device_label = "cpu"
-        else:
-            raise BackendUnavailable(f"Unsupported torch device: {device}")
 
-        self.torch.manual_seed(seed)
+        # A local generator, so constructing a backend does not perturb the
+        # global torch RNG that other code in this process may depend on.
+        self.generator = self.torch.Generator(device=self.device)
+        self.generator.manual_seed(seed)
+
+    def _torch_dtype(self, dtype: str | None) -> Any:
+        if dtype is None:
+            return self.dtype
+        return {
+            "float32": self.torch.float32,
+            "float64": self.torch.float64,
+            "float16": self.torch.float16,
+            "bfloat16": self.torch.bfloat16,
+        }[validate_dtype(dtype)]
 
     def asarray(self, value: Any, *, dtype: str | None = None) -> Any:
-        resolved_dtype = (
-            self.dtype
-            if dtype is None
-            else {
-                "float32": self.torch.float32,
-                "float64": self.torch.float64,
-                "float16": self.torch.float16,
-                "bfloat16": self.torch.bfloat16,
-            }[dtype]
-        )
+        resolved_dtype = self._torch_dtype(dtype)
+        if self.torch.is_tensor(value):
+            return value.to(device=self.device, dtype=resolved_dtype)
         return self.torch.tensor(value, dtype=resolved_dtype, device=self.device)
 
     def full(self, shape: tuple[int, ...], value: float) -> Any:
@@ -245,52 +340,71 @@ class TorchBackend(ArrayBackend):
         return self.torch.zeros(shape, dtype=self.dtype, device=self.device)
 
     def normal(self, *, mean: float, sigma: float, shape: tuple[int, ...], seed_offset: int) -> Any:
-        self.torch.manual_seed(self.seed + seed_offset)
-        return self.torch.normal(mean=mean, std=sigma, size=shape, dtype=self.dtype, device=self.device)
+        generator = self.torch.Generator(device=self.device)
+        generator.manual_seed(self.seed + seed_offset)
+        return self.torch.normal(
+            mean=mean, std=sigma, size=shape, dtype=self.dtype, device=self.device, generator=generator
+        )
 
     def clip(self, value: Any, lower: float, upper: float) -> Any:
         return self.torch.clamp(value, min=lower, max=upper)
 
     def maximum(self, left: Any, right: Any) -> Any:
+        # clamp takes a Python scalar directly. torch.maximum does not, and
+        # wrapping the scalar in a tensor costs an allocation plus a host->device
+        # copy on every call -- hundreds of thousands of them over a sweep.
         if not self.torch.is_tensor(right):
-            right = self.torch.tensor(right, dtype=self.dtype, device=self.device)
+            return self.torch.clamp(left, min=float(right))
+        if not self.torch.is_tensor(left):
+            return self.torch.clamp(right, min=float(left))
         return self.torch.maximum(left, right)
 
     def minimum(self, left: Any, right: Any) -> Any:
         if not self.torch.is_tensor(right):
-            right = self.torch.tensor(right, dtype=self.dtype, device=self.device)
+            return self.torch.clamp(left, max=float(right))
+        if not self.torch.is_tensor(left):
+            return self.torch.clamp(right, max=float(left))
         return self.torch.minimum(left, right)
 
     def sum(self, value: Any, axis: int | None = None) -> Any:
         return self.torch.sum(value) if axis is None else self.torch.sum(value, dim=axis)
 
     def stack(self, values: list[Any], axis: int = 0) -> Any:
-        return self.torch.stack(values, dim=axis)
+        return self.torch.stack([self.asarray(value) for value in values], dim=axis)
 
     def roll(self, value: Any, *, shift: int, axis: int) -> Any:
         return self.torch.roll(value, shifts=shift, dims=axis)
 
-    def percentiles(self, value: Any, quantiles: tuple[float, float, float]) -> list[float]:
+    def _quantile_tensor(self, value: Any, quantiles: tuple[float, float, float]) -> Any:
+        """Quantiles as a device tensor, without transferring anything to the host."""
         flat = value.flatten()
-        try:
+        if int(flat.numel()) <= TORCH_QUANTILE_MAX_ELEMENTS:
             q = self.torch.tensor(quantiles, dtype=self.dtype, device=self.device)
-            return self.to_host_list(self.torch.quantile(flat, q))
-        except Exception:
-            ordered = self.torch.sort(flat).values
-            count = int(ordered.numel())
-            resolved: list[float] = []
-            for quantile in quantiles:
-                position = quantile * max(count - 1, 0)
-                lower_index = int(math.floor(position))
-                upper_index = int(math.ceil(position))
-                if lower_index == upper_index:
-                    resolved.append(self.scalar(ordered[lower_index]))
-                else:
-                    fraction = position - lower_index
-                    lower = self.scalar(ordered[lower_index])
-                    upper = self.scalar(ordered[upper_index])
-                    resolved.append(lower + (upper - lower) * fraction)
-            return resolved
+            return self.torch.quantile(flat, q)
+        # torch.quantile refuses larger inputs; sort and interpolate on device.
+        ordered = self.torch.sort(flat).values
+        count = int(ordered.numel())
+        picks = []
+        for quantile in quantiles:
+            position = quantile * max(count - 1, 0)
+            lower_index = int(math.floor(position))
+            upper_index = min(int(math.ceil(position)), max(count - 1, 0))
+            fraction = position - lower_index
+            lower = ordered[lower_index]
+            picks.append(lower if lower_index == upper_index else lower + (ordered[upper_index] - lower) * fraction)
+        return self.torch.stack(picks)
+
+    def percentiles(self, value: Any, quantiles: tuple[float, float, float]) -> list[float]:
+        return self.to_host_list(self._quantile_tensor(value, quantiles))
+
+    def percentiles_batch(self, values: list[Any], quantiles: tuple[float, float, float]) -> list[list[float]]:
+        if not values:
+            return []
+        # One host transfer for every series in the step, instead of one each.
+        stacked = self.torch.stack([self._quantile_tensor(value, quantiles) for value in values])
+        flat = self.to_host_list(stacked)
+        width = len(quantiles)
+        return [flat[index * width : (index + 1) * width] for index in range(len(values))]
 
     def max_scalar(self, value: Any) -> float:
         return self.scalar(self.torch.max(value))
@@ -324,6 +438,30 @@ class TorchBackend(ArrayBackend):
                 return None
         return None
 
+    def max_memory_allocated_bytes(self) -> int | None:
+        if self.device.type == "xpu":
+            try:
+                return int(self.torch.xpu.max_memory_allocated())
+            except Exception:
+                return None
+        return None
+
+    def reset_peak_memory_stats(self) -> None:
+        if self.device.type == "xpu":
+            try:
+                self.torch.xpu.reset_peak_memory_stats()
+            except Exception:
+                return None
+        return None
+
+    def device_total_memory_bytes(self) -> int | None:
+        if self.device.type == "xpu":
+            try:
+                return int(self.torch.xpu.get_device_properties(0).total_memory)
+            except Exception:
+                return None
+        return None
+
 
 def create_array_backend(
     name: str, *, dtype: str = DEFAULT_DTYPE, seed: int = 42
@@ -339,6 +477,14 @@ def create_array_backend(
     raise BackendUnavailable(f"Unsupported array backend: {name}")
 
 
+#: Ensemble size below which GPU offload is not worth the device-init and
+#: per-step launch overhead. Measured on an Intel Arc Pro B70 against
+#: ``flagship_grid_stress``: 1.4x at 65,536 samples, 12.4x at 262,144, and
+#: 49.6x at 1,048,576 -- the fixed per-step cost is what the ensemble has to
+#: amortize, so small ensembles get an advisory in the selection reason.
+GPU_EFFICIENT_SAMPLE_FLOOR = 131_072
+
+
 def resolve_runtime_backend(
     requested: str,
     *,
@@ -346,25 +492,51 @@ def resolve_runtime_backend(
     dtype: str = DEFAULT_DTYPE,
     seed: int = 42,
 ) -> BackendSelection:
+    """Pick a backend, and say honestly why.
+
+    ``samples`` shapes the recorded reason: the vectorized integrator pays a
+    fixed per-step launch and synchronization cost, so an ensemble below
+    :data:`GPU_EFFICIENT_SAMPLE_FLOOR` gets little from the GPU and the
+    selection says so. It is still honoured -- the GPU is never slower here,
+    just under-used -- but the bundle records that the run was in that regime.
+    """
     requested = requested.strip().lower()
     if requested not in (*SUPPORTED_ARRAY_BACKENDS, "auto"):
-        raise BackendUnavailable(f"Unsupported array backend: {requested}")
-    if requested != "auto":
-        create_array_backend(requested, dtype=dtype, seed=seed)
-        return BackendSelection(
-            requested=requested, selected=requested, reason="explicit backend requested", dtype=dtype
+        raise BackendUnavailable(
+            f"Unsupported array backend: {requested!r}. Choose one of auto, {', '.join(SUPPORTED_ARRAY_BACKENDS)}."
         )
+    validate_dtype(dtype)
+
+    if requested != "auto":
+        # Constructing here surfaces an unavailable backend as an error the
+        # caller can act on, rather than a silent downgrade.
+        create_array_backend(requested, dtype=dtype, seed=seed)
+        selected_dtype = REFERENCE_DTYPE if requested == "python" else dtype
+        return BackendSelection(
+            requested=requested,
+            selected=requested,
+            reason="explicit backend requested",
+            dtype=selected_dtype,
+        )
+
+    undersized = (
+        f" Note: {samples:,} samples is below the {GPU_EFFICIENT_SAMPLE_FLOOR:,}-sample floor where GPU offload"
+        " amortizes its per-step launch overhead, so the device is under-used at this ensemble size."
+        if samples < GPU_EFFICIENT_SAMPLE_FLOOR
+        else ""
+    )
 
     try:
         create_array_backend("torch-xpu", dtype=dtype, seed=seed)
         return BackendSelection(
             requested=requested,
             selected="torch-xpu",
-            reason="auto mode prefers torch-xpu when available",
+            reason=f"auto mode prefers torch-xpu when available.{undersized}".strip(),
             dtype=dtype,
         )
     except Exception as exc:
-        gpu_error = exc
+        gpu_error: Exception = exc
+
     try:
         create_array_backend("numpy", dtype=dtype, seed=seed)
         return BackendSelection(
@@ -373,25 +545,44 @@ def resolve_runtime_backend(
             reason=f"torch-xpu unavailable ({gpu_error}); numpy CPU vector backend is available",
             dtype=dtype,
         )
-    except Exception:
-        return BackendSelection(
-            requested=requested,
-            selected="python",
-            reason="falling back to pure Python reference backend",
-            dtype="float64",
-        )
+    except Exception as exc:
+        numpy_error: Exception = exc
+
+    return BackendSelection(
+        requested=requested,
+        selected="python",
+        reason=(
+            f"falling back to pure Python reference backend: torch-xpu unavailable ({gpu_error}); "
+            f"numpy unavailable ({numpy_error}). This is far slower and runs in float64."
+        ),
+        dtype=REFERENCE_DTYPE,
+    )
 
 
-def backend_report_for_selection(selection: BackendSelection, *, seed: int = 42) -> dict[str, Any]:
+def backend_report_for_selection(
+    selection: BackendSelection,
+    *,
+    seed: int = 42,
+    backend: ArrayBackend | PythonReferenceBackend | None = None,
+) -> dict[str, Any]:
+    """Describe the backend that will actually run.
+
+    Pass ``backend`` to describe an already-constructed instance; that avoids
+    building the device context a second time purely to write the report.
+    """
     try:
-        backend = create_array_backend(selection.selected, dtype=selection.dtype, seed=seed)
-        details = backend.describe()
+        described = (
+            backend
+            if backend is not None
+            else create_array_backend(selection.selected, dtype=selection.dtype, seed=seed)
+        )
+        details = described.describe()
         available = True
         reason = selection.reason
-    except BaseException as exc:
+    except Exception as exc:
         details = None
         available = False
-        reason = str(exc)
+        reason = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
     return {
         "requested": selection.requested,
         "selected": selection.selected,
@@ -400,3 +591,43 @@ def backend_report_for_selection(selection: BackendSelection, *, seed: int = 42)
         "details": details,
         "environment": runtime_environment_report(),
     }
+
+
+def estimate_state_bytes(*, samples: int, dtype: str, groups: int, loop_segments: int) -> int:
+    """Approximate device bytes the vectorized integrator holds live.
+
+    Roughly 30 per-sample state/temporary arrays, plus the precursor core
+    inventory (groups) and segment inventory (groups x segments), plus the 11
+    perturbation arrays that live for the whole run.
+    """
+    width = {"float16": 2, "bfloat16": 2, "float32": 4, "float64": 8}[validate_dtype(dtype)]
+    per_sample_slots = 30 + 11 + groups + groups * loop_segments
+    return int(samples) * per_sample_slots * width
+
+
+def check_memory_budget(
+    backend: ArrayBackend | PythonReferenceBackend,
+    *,
+    samples: int,
+    dtype: str,
+    groups: int,
+    loop_segments: int,
+    headroom_fraction: float = 0.8,
+) -> dict[str, Any]:
+    """Refuse an ensemble that cannot fit, instead of discovering it at step 1."""
+    estimated = estimate_state_bytes(samples=samples, dtype=dtype, groups=groups, loop_segments=loop_segments)
+    total = getattr(backend, "device_total_memory_bytes", lambda: None)()
+    budget = {
+        "estimated_state_bytes": estimated,
+        "device_total_bytes": total,
+        "headroom_fraction": headroom_fraction,
+        "status": "ok",
+    }
+    if total is not None and estimated > total * headroom_fraction:
+        budget["status"] = "insufficient"
+        raise BackendUnavailable(
+            f"Ensemble of {samples:,} samples needs about {estimated / 2**30:.1f} GiB of device memory, "
+            f"which exceeds {headroom_fraction:.0%} of the {total / 2**30:.1f} GiB available on "
+            f"{getattr(backend, 'device_label', 'the device')}. Reduce --samples or use --dtype float32."
+        )
+    return budget

--- a/src/thorium_reactor/accelerators.py
+++ b/src/thorium_reactor/accelerators.py
@@ -143,11 +143,23 @@ class ArrayBackend:
         """
         return [self.percentiles(value, quantiles) for value in values]
 
-    def max_scalar(self, value: Any) -> float:
+    def amax(self, value: Any) -> Any:
+        """Maximum as a *device* scalar, without transferring to the host.
+
+        Lets a caller fold a running extremum across many steps and pay a
+        single synchronization at the end instead of one per step.
+        """
         raise NotImplementedError
 
-    def min_scalar(self, value: Any) -> float:
+    def amin(self, value: Any) -> Any:
+        """Minimum as a device scalar. See :meth:`amax`."""
         raise NotImplementedError
+
+    def max_scalar(self, value: Any) -> float:
+        return self.scalar(self.amax(value))
+
+    def min_scalar(self, value: Any) -> float:
+        return self.scalar(self.amin(value))
 
     def scalar(self, value: Any) -> float:
         raise NotImplementedError
@@ -245,11 +257,11 @@ class NumpyBackend(ArrayBackend):
         raw = self.xp.percentile(value, self.xp.asarray([item * 100.0 for item in quantiles], dtype=self.dtype))
         return [float(item) for item in self.to_host_list(raw)]
 
-    def max_scalar(self, value: Any) -> float:
-        return self.scalar(self.xp.max(value))
+    def amax(self, value: Any) -> Any:
+        return self.xp.max(value)
 
-    def min_scalar(self, value: Any) -> float:
-        return self.scalar(self.xp.min(value))
+    def amin(self, value: Any) -> Any:
+        return self.xp.min(value)
 
     def scalar(self, value: Any) -> float:
         if hasattr(value, "item"):
@@ -351,20 +363,38 @@ class TorchBackend(ArrayBackend):
 
     def maximum(self, left: Any, right: Any) -> Any:
         # clamp takes a Python scalar directly. torch.maximum does not, and
-        # wrapping the scalar in a tensor costs an allocation plus a host->device
-        # copy on every call -- hundreds of thousands of them over a sweep.
-        if not self.torch.is_tensor(right):
-            return self.torch.clamp(left, min=float(right))
-        if not self.torch.is_tensor(left):
-            return self.torch.clamp(right, min=float(left))
-        return self.torch.maximum(left, right)
+        # wrapping the scalar in a tensor costs an allocation plus a
+        # host->device copy on every call -- hundreds of thousands of them over
+        # a sweep. clamp is only equivalent for a *finite* bound, though:
+        # torch.maximum(x, nan) propagates nan, while clamp(x, min=nan) leaves
+        # x untouched, so a non-finite bound must take the tensor path or a
+        # corrupt threshold would be silently ignored.
+        scalar_bound = self._finite_scalar(right if not self.torch.is_tensor(right) else None)
+        if scalar_bound is not None:
+            return self.torch.clamp(left, min=scalar_bound)
+        scalar_bound = self._finite_scalar(left if not self.torch.is_tensor(left) else None)
+        if scalar_bound is not None:
+            return self.torch.clamp(right, min=scalar_bound)
+        return self.torch.maximum(self.asarray(left), self.asarray(right))
 
     def minimum(self, left: Any, right: Any) -> Any:
-        if not self.torch.is_tensor(right):
-            return self.torch.clamp(left, max=float(right))
-        if not self.torch.is_tensor(left):
-            return self.torch.clamp(right, max=float(left))
-        return self.torch.minimum(left, right)
+        scalar_bound = self._finite_scalar(right if not self.torch.is_tensor(right) else None)
+        if scalar_bound is not None:
+            return self.torch.clamp(left, max=scalar_bound)
+        scalar_bound = self._finite_scalar(left if not self.torch.is_tensor(left) else None)
+        if scalar_bound is not None:
+            return self.torch.clamp(right, max=scalar_bound)
+        return self.torch.minimum(self.asarray(left), self.asarray(right))
+
+    @staticmethod
+    def _finite_scalar(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            resolved = float(value)
+        except (TypeError, ValueError):
+            return None
+        return resolved if math.isfinite(resolved) else None
 
     def sum(self, value: Any, axis: int | None = None) -> Any:
         return self.torch.sum(value) if axis is None else self.torch.sum(value, dim=axis)
@@ -378,8 +408,13 @@ class TorchBackend(ArrayBackend):
     def _quantile_tensor(self, value: Any, quantiles: tuple[float, float, float]) -> Any:
         """Quantiles as a device tensor, without transferring anything to the host."""
         flat = value.flatten()
+        if flat.dtype not in (self.torch.float32, self.torch.float64):
+            # torch.quantile and torch.sort interpolation accept only float or
+            # double; half precisions are advertised by the backend, so upcast
+            # rather than surfacing a dtype error from deep in the reduction.
+            flat = flat.to(self.torch.float32)
         if int(flat.numel()) <= TORCH_QUANTILE_MAX_ELEMENTS:
-            q = self.torch.tensor(quantiles, dtype=self.dtype, device=self.device)
+            q = self.torch.tensor(quantiles, dtype=flat.dtype, device=self.device)
             return self.torch.quantile(flat, q)
         # torch.quantile refuses larger inputs; sort and interpolate on device.
         ordered = self.torch.sort(flat).values
@@ -406,11 +441,11 @@ class TorchBackend(ArrayBackend):
         width = len(quantiles)
         return [flat[index * width : (index + 1) * width] for index in range(len(values))]
 
-    def max_scalar(self, value: Any) -> float:
-        return self.scalar(self.torch.max(value))
+    def amax(self, value: Any) -> Any:
+        return self.torch.max(value)
 
-    def min_scalar(self, value: Any) -> float:
-        return self.scalar(self.torch.min(value))
+    def amin(self, value: Any) -> Any:
+        return self.torch.min(value)
 
     def scalar(self, value: Any) -> float:
         if self.torch.is_tensor(value):

--- a/src/thorium_reactor/cli.py
+++ b/src/thorium_reactor/cli.py
@@ -101,7 +101,11 @@ def build_parser() -> argparse.ArgumentParser:
                 help="Number of ensemble trajectories to evaluate.",
             )
             command.add_argument("--seed", type=int, default=42, help="Random seed for the ensemble perturbations.")
-            command.add_argument("--prefer-gpu", action="store_true", help="Deprecated alias for --backend auto.")
+            command.add_argument(
+                "--prefer-gpu",
+                action="store_true",
+                help="Deprecated alias for --backend auto. Cannot be combined with an explicit --backend.",
+            )
             command.add_argument(
                 "--backend",
                 default="auto",
@@ -360,6 +364,9 @@ def main(argv: list[str] | None = None) -> int:
             )
             print(bundle.root)
             print(transient_sweep["backend"])
+            device = (transient_sweep.get("backend_report") or {}).get("details") or {}
+            if device.get("device"):
+                print(f"{device['device']} ({device.get('dtype', '')})".strip())
             print(transient_sweep["metrics"]["peak_power_fraction_p95"])
             return 0
 
@@ -710,7 +717,15 @@ def main(argv: list[str] | None = None) -> int:
                 status="completed" if result.get("passed") else "failed",
             )
             print(result["passed"])
-            return 0
+            for check in result.get("checks", []):
+                if isinstance(check, dict) and check.get("status") != "pass":
+                    print(f"{check.get('status', 'unknown').upper()}: {check.get('name')}", file=sys.stderr)
+                    if check.get("message"):
+                        print(f"  {check['message']}", file=sys.stderr)
+            # Exit non-zero when the gate did not pass, so a script or CI job can
+            # act on it. `qa` already behaves this way; `validate` did not, which
+            # made a failing validation indistinguishable from a passing one.
+            return 0 if result.get("passed") else 1
 
         if args.command == "render":
             summary_path = bundle.root / "summary.json"

--- a/src/thorium_reactor/paths.py
+++ b/src/thorium_reactor/paths.py
@@ -164,7 +164,7 @@ def append_stage_manifest(
     if message:
         record["message"] = message
     stages.append(record)
-    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    atomic_write_text(manifest_path, json.dumps(manifest, indent=2, sort_keys=True))
     return manifest
 
 
@@ -186,7 +186,7 @@ def refresh_bundle_artifact_statuses(bundle: ResultBundle, *, summary: dict[str,
         status["groups"]["benchmark_evidence"] = _benchmark_evidence_group_status(bundle, summary)
     status["blockers"] = [blocker for group in status["groups"].values() for blocker in group.get("blockers", [])]
     status["warnings"] = [warning for group in status["groups"].values() for warning in group.get("warnings", [])]
-    (bundle.root / "artifact_status.json").write_text(json.dumps(status, indent=2, sort_keys=True), encoding="utf-8")
+    atomic_write_text(bundle.root / "artifact_status.json", json.dumps(status, indent=2, sort_keys=True))
     _write_directory_status(bundle.openmc_dir, status["groups"]["openmc"])
     _write_directory_status(bundle.images_dir, status["groups"]["images"])
     _write_directory_status(bundle.geometry_exports_dir, status["groups"]["geometry_exports"])
@@ -379,7 +379,7 @@ def _directory_artifacts(directory: Path) -> list[str]:
 
 def _write_directory_status(directory: Path, payload: dict[str, Any]) -> None:
     directory.mkdir(parents=True, exist_ok=True)
-    (directory / "status.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    atomic_write_text(directory / "status.json", json.dumps(payload, indent=2, sort_keys=True))
 
 
 def _relative_artifact_path(bundle: ResultBundle, path: Path) -> str:

--- a/src/thorium_reactor/reporting/reports.py
+++ b/src/thorium_reactor/reporting/reports.py
@@ -741,13 +741,22 @@ def generate_report(
             lines.append(
                 f"- Percentile definitions: `{ensemble_definition.get('percentile_definitions', 'sample percentiles by time step')}`"
             )
-            for parameter in ensemble_definition.get("varied_parameters", [])[:8]:
-                if isinstance(parameter, dict):
-                    lines.append(
-                        f"- Varied `{parameter.get('parameter')}`: unit=`{parameter.get('units')}`, "
-                        f"distribution=`{parameter.get('distribution')}`, bounds=`{parameter.get('bounds')}`, "
-                        f"basis={parameter.get('physical_basis')}"
-                    )
+            # Every varied parameter, not the first eight. The flagship ensemble
+            # perturbs eleven, so the old cap silently dropped three of the
+            # dimensions the sweep actually sampled from the document that
+            # describes the sweep.
+            varied_parameters = [
+                parameter
+                for parameter in ensemble_definition.get("varied_parameters", [])
+                if isinstance(parameter, dict)
+            ]
+            lines.append(f"- Varied parameter count: `{len(varied_parameters)}`")
+            for parameter in varied_parameters:
+                lines.append(
+                    f"- Varied `{parameter.get('parameter')}`: unit=`{parameter.get('units')}`, "
+                    f"distribution=`{parameter.get('distribution')}`, bounds=`{parameter.get('bounds')}`, "
+                    f"basis={parameter.get('physical_basis')}"
+                )
         lines.append(f"- Duration (s): `{transient_sweep.get('duration_s', 'n/a')}`")
         lines.append(f"- Time step (s): `{transient_sweep.get('time_step_s', 'n/a')}`")
         lines.append(f"- Event count: `{transient_sweep.get('event_count', 'n/a')}`")

--- a/src/thorium_reactor/runtime_context.py
+++ b/src/thorium_reactor/runtime_context.py
@@ -41,6 +41,9 @@ def build_runtime_context(*, command: list[str] | None = None, cwd: Path | str |
         "backend": {
             "service": service,
             "device": os.environ.get("THORIUM_REACTOR_DEVICE", "host-cpu"),
+            # What the process could actually compute on. Without this a GPU
+            # bundle and a CPU bundle are indistinguishable in provenance.
+            "accelerator": _accelerator_summary(),
         },
         "dependencies": dependency_summary,
         "dependency_hash": _stable_hash(dependency_summary),
@@ -278,6 +281,11 @@ def _dependency_summary() -> dict[str, str]:
         "fastapi",
         "pydantic",
         "matplotlib",
+        # The accelerated transient sweep runs on torch, so its version is part
+        # of what produced the numbers and belongs in the dependency hash. Its
+        # absence made a CPU bundle and a GPU bundle hash identically.
+        "torch",
+        "intel-extension-for-pytorch",
     )
     summary: dict[str, str] = {}
     for name in package_names:
@@ -285,6 +293,31 @@ def _dependency_summary() -> dict[str, str]:
             summary[name] = importlib.metadata.version(name)
         except importlib.metadata.PackageNotFoundError:
             continue
+    return summary
+
+
+def _accelerator_summary() -> dict[str, Any]:
+    """Describe available compute devices without importing torch to find out.
+
+    Importing torch here would make every CLI command pay the import cost and
+    would defeat the ordering guard in ``accelerators``; so this only reports
+    what is already loaded, plus the environment that selects a device.
+    """
+    summary: dict[str, Any] = {
+        "torch_imported": "torch" in sys.modules,
+        "oneapi_device_selector": os.environ.get("ONEAPI_DEVICE_SELECTOR"),
+        "pytorch_xpu_fallback": os.environ.get("PYTORCH_ENABLE_XPU_FALLBACK"),
+    }
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return summary
+    summary["torch_version"] = getattr(torch, "__version__", None)
+    try:
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            summary["xpu_device_count"] = int(torch.xpu.device_count())
+            summary["xpu_devices"] = [torch.xpu.get_device_name(i) for i in range(torch.xpu.device_count())]
+    except Exception:
+        summary["xpu_devices"] = None
     return summary
 
 

--- a/src/thorium_reactor/sidecar_schemas.py
+++ b/src/thorium_reactor/sidecar_schemas.py
@@ -126,6 +126,56 @@ def validate_figure_catalog(payload: Any, *, artifact: str = "plots_manifest.jso
     return data
 
 
+def validate_transient_sweep(payload: Any, *, artifact: str = "transient_sweep.json") -> dict[str, Any]:
+    """Validate the accelerated ensemble artifact.
+
+    The sweep is the one artifact whose numbers depend on which device produced
+    them, so the checks here are about attribution as much as shape: a bundle
+    must not be able to claim a backend it did not run, or record a numerical
+    status of "failed" alongside published metrics.
+    """
+    data = _require_mapping(payload, artifact, "<root>")
+    for field in ("case", "model", "backend"):
+        _require_str(data, artifact, field, value=data.get(field))
+    for field in ("samples", "seed"):
+        value = data.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise SidecarValidationError(artifact, field, "must be a non-negative integer")
+
+    report = _require_mapping(data.get("backend_report"), artifact, "backend_report")
+    for field in ("requested", "selected"):
+        _require_str(report, artifact, f"backend_report.{field}", value=report.get(field))
+    if report.get("selected") != data.get("backend"):
+        raise SidecarValidationError(
+            artifact,
+            "backend",
+            f"backend {data.get('backend')!r} disagrees with backend_report.selected {report.get('selected')!r}",
+        )
+    if not isinstance(report.get("available"), bool):
+        raise SidecarValidationError(artifact, "backend_report.available", "must be a boolean")
+    if report.get("available") and not isinstance(report.get("details"), dict):
+        raise SidecarValidationError(
+            artifact, "backend_report.details", "must describe the device when the backend is available"
+        )
+
+    checks = _require_mapping(data.get("numerical_checks"), artifact, "numerical_checks")
+    status = checks.get("status")
+    if status != "ok":
+        raise SidecarValidationError(
+            artifact,
+            "numerical_checks.status",
+            f"is {status!r}; a bundle must not publish sweep metrics that failed their own numerical checks",
+        )
+
+    metrics = _require_mapping(data.get("metrics"), artifact, "metrics")
+    if metrics.get("samples") != data.get("samples"):
+        raise SidecarValidationError(artifact, "metrics.samples", "disagrees with the recorded sample count")
+    history = data.get("history")
+    if not isinstance(history, list) or not history:
+        raise SidecarValidationError(artifact, "history", "must be a non-empty list of recorded time steps")
+    return data
+
+
 _SIDECAR_VALIDATORS = {
     "artifact_status.json": validate_artifact_status,
     "stage_manifest.json": validate_stage_manifest,
@@ -133,6 +183,7 @@ _SIDECAR_VALIDATORS = {
     "design_readiness.json": validate_design_readiness,
     "result_claims.json": validate_result_claims,
     "plots_manifest.json": validate_figure_catalog,
+    "transient_sweep.json": validate_transient_sweep,
 }
 
 

--- a/src/thorium_reactor/transient_sweep.py
+++ b/src/thorium_reactor/transient_sweep.py
@@ -208,6 +208,22 @@ def _resolve_requested_backend(backend: str, *, prefer_gpu: bool) -> str:
     return requested
 
 
+def _effective_loop_segments(
+    model_parameters: dict[str, Any], baseline: dict[str, Any]
+) -> list[dict[str, float | str]]:
+    """The loop segments the vectorized integrator will actually allocate.
+
+    Honours the configured precursor transport model, as the reference
+    integrator does. The two-region model is algebraically the single-segment
+    case of the segmented model -- same steady state, same implicit step -- so
+    collapsing the segment list reproduces it exactly.
+    """
+    transport_model = str(model_parameters["precursor_transport_model"])
+    if transport_model == LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL:
+        return normalize_loop_segments(baseline.get("precursor_loop_segments"))
+    return normalize_loop_segments(None)
+
+
 def _bundle_relative_path(path: Any) -> str:
     """Path recorded in the bundle, relative to the repository root.
 
@@ -420,12 +436,15 @@ def _integrate_transient_ensemble(
     vector_backend = create_array_backend(selection.selected, dtype=selection.dtype, seed=seed)
     assert isinstance(vector_backend, ArrayBackend)
     # Refuse an ensemble that cannot fit before spending minutes discovering it.
+    # Budget the segment count the integrator will actually allocate: the
+    # two-region model collapses to a single segment regardless of how many the
+    # case configures, so using the configured count would reject a run that fits.
     memory_budget = check_memory_budget(
         vector_backend,
         samples=samples,
         dtype=selection.dtype,
         groups=len(list(model_parameters["delayed_neutron_precursor_groups"])),
-        loop_segments=len(normalize_loop_segments(baseline.get("precursor_loop_segments"))),
+        loop_segments=len(_effective_loop_segments(model_parameters, baseline)),
     )
     return _integrate_transient_ensemble_vectorized(
         array_backend=vector_backend,
@@ -851,10 +870,8 @@ def _integrate_transient_ensemble_reference(
         peak_power_fraction_max = max(peak_power_fraction_max, max(power_fraction))
         peak_fuel_temperature_c_max = max(peak_fuel_temperature_c_max, max(fuel_temp_c))
         peak_corrosion_index_max = max(peak_corrosion_index_max, max(corrosion_index))
-        _observe_trajectory_health(
+        _observe_trajectory_extrema(
             trajectory_health,
-            step=step,
-            time_s=time_s,
             power_min=min(power_fraction),
             power_max=max(power_fraction),
             temp_min=min(min(fuel_temp_c), min(graphite_temp_c), min(coolant_temp_c)),
@@ -862,8 +879,8 @@ def _integrate_transient_ensemble_reference(
             fissile_min=min(fissile_inventory_fraction),
             protactinium_min=min(protactinium_inventory_fraction),
             corrosion_min=min(corrosion_index),
-            history_row=history[-1],
         )
+        _observe_trajectory_history(trajectory_health, step=step, time_s=time_s, history_row=history[-1])
 
     metrics = {
         "duration_s": _round_float(duration_s),
@@ -973,16 +990,7 @@ def _integrate_transient_ensemble_vectorized(
     )
 
     groups = list(model_parameters["delayed_neutron_precursor_groups"])
-    # Honour the configured precursor transport model, as the reference
-    # integrator does. The two-region model is algebraically the single-segment
-    # case of the segmented model -- same steady state, same implicit step -- so
-    # collapsing the segment list is enough to reproduce it exactly.
-    transport_model = str(model_parameters["precursor_transport_model"])
-    loop_segments = (
-        normalize_loop_segments(baseline.get("precursor_loop_segments"))
-        if transport_model == LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL
-        else normalize_loop_segments(None)
-    )
+    loop_segments = _effective_loop_segments(model_parameters, baseline)
     initial_flow_fraction = backend.clip(perturbations["flow_scale"], 0.05, 1.5)
     initial_cleanup_rate_s = float(baseline["cleanup_removal_efficiency"]) * backend.clip(
         perturbations["cleanup_scale"], 0.0, 2.5
@@ -1022,6 +1030,7 @@ def _integrate_transient_ensemble_vectorized(
     )
 
     trajectory_health = _new_trajectory_health()
+    device_extrema: dict[str, Any] = {}
 
     backend.synchronize()
     setup_elapsed_s = time.perf_counter() - setup_start
@@ -1257,25 +1266,21 @@ def _integrate_transient_ensemble_vectorized(
         peak_power_fraction_max = max(peak_power_fraction_max, backend.max_scalar(power_fraction))
         peak_fuel_temperature_c_max = max(peak_fuel_temperature_c_max, backend.max_scalar(fuel_temp_c))
         peak_corrosion_index_max = max(peak_corrosion_index_max, backend.max_scalar(corrosion_index))
-        # Percentile bands already crossed to the host this step, so the
-        # trajectory health screen costs no extra synchronization.
-        _observe_trajectory_health(
-            trajectory_health,
-            step=step,
-            time_s=time_s,
-            # Bands, not per-sample extrema: reading true min/max every step
-            # would add two device synchronizations per step for a quantity the
-            # final-step check already covers exactly. The band still catches a
-            # trajectory that leaves the physical envelope.
-            power_min=power_band[0],
-            power_max=peak_power_fraction_max,
-            temp_min=fuel_band[0],
-            temp_max=peak_fuel_temperature_c_max,
-            fissile_min=None,
-            protactinium_min=None,
-            corrosion_min=corrosion_band[0],
-            history_row=history[-1],
+        # Exact per-sample extrema over every state, accumulated as device
+        # scalars. Percentile bands would miss an excursion confined to fewer
+        # than 5% of samples, and reducing to the host each step would cost a
+        # synchronization -- so reduce on device here and read the accumulators
+        # once, after the loop.
+        device_extrema = _accumulate_device_extrema(
+            backend,
+            device_extrema,
+            power_fraction=power_fraction,
+            temperatures=(fuel_temp_c, graphite_temp_c, coolant_temp_c),
+            corrosion_index=corrosion_index,
+            fissile_inventory_fraction=fissile_inventory_fraction,
+            protactinium_inventory_fraction=protactinium_inventory_fraction,
         )
+        _observe_trajectory_history(trajectory_health, step=step, time_s=time_s, history_row=history[-1])
 
     backend.synchronize()
     elapsed_s = time.perf_counter() - integrate_start
@@ -1314,13 +1319,7 @@ def _integrate_transient_ensemble_vectorized(
         backend,
         metrics=metrics,
         trajectory_health=trajectory_health,
-        power_fraction=power_fraction,
-        fuel_temp_c=fuel_temp_c,
-        graphite_temp_c=graphite_temp_c,
-        coolant_temp_c=coolant_temp_c,
-        fissile_inventory_fraction=fissile_inventory_fraction,
-        protactinium_inventory_fraction=protactinium_inventory_fraction,
-        corrosion_index=corrosion_index,
+        device_extrema=device_extrema,
         core_inventory=core_inventory,
         segment_inventory=segment_inventory,
     )
@@ -1546,40 +1545,77 @@ def _new_trajectory_health() -> dict[str, Any]:
     }
 
 
-def _observe_trajectory_health(
-    health: dict[str, Any],
-    *,
-    step: int,
-    time_s: float,
-    power_min: float,
-    power_max: float,
-    temp_min: float,
-    temp_max: float,
-    fissile_min: float | None,
-    protactinium_min: float | None,
-    corrosion_min: float,
-    history_row: dict[str, Any],
+def _observe_trajectory_history(
+    health: dict[str, Any], *, step: int, time_s: float, history_row: dict[str, Any]
 ) -> None:
-    """Screen every recorded step, not just the last one.
+    """Screen every recorded step for a non-finite percentile band.
 
-    A transient that goes non-finite or negative mid-flight and recovers by the
-    final step used to pass silently; the sweep is a stress-test envelope, so an
-    excursion anywhere in the trajectory is exactly what we need to catch.
+    The band values already crossed to the host this step, so this costs no
+    extra synchronization. Per-sample extrema are tracked separately, on device.
     """
     health["steps_observed"] += 1
-    health["power_fraction_min"] = min(health["power_fraction_min"], power_min)
-    health["power_fraction_max"] = max(health["power_fraction_max"], power_max)
-    health["temperature_min_c"] = min(health["temperature_min_c"], temp_min)
-    health["temperature_max_c"] = max(health["temperature_max_c"], temp_max)
-    if fissile_min is not None:
-        health["fissile_inventory_min"] = min(health["fissile_inventory_min"], fissile_min)
-    if protactinium_min is not None:
-        health["protactinium_inventory_min"] = min(health["protactinium_inventory_min"], protactinium_min)
-    health["corrosion_index_min"] = min(health["corrosion_index_min"], corrosion_min)
     if len(health["non_finite_steps"]) < 8 and not all(
         math.isfinite(float(value)) for value in history_row.values() if isinstance(value, (int, float))
     ):
         health["non_finite_steps"].append({"step": step, "time_s": _round_float(time_s)})
+
+
+def _observe_trajectory_extrema(
+    health: dict[str, Any],
+    *,
+    power_min: float,
+    power_max: float,
+    temp_min: float,
+    temp_max: float,
+    fissile_min: float,
+    protactinium_min: float,
+    corrosion_min: float,
+) -> None:
+    health["power_fraction_min"] = min(health["power_fraction_min"], power_min)
+    health["power_fraction_max"] = max(health["power_fraction_max"], power_max)
+    health["temperature_min_c"] = min(health["temperature_min_c"], temp_min)
+    health["temperature_max_c"] = max(health["temperature_max_c"], temp_max)
+    health["fissile_inventory_min"] = min(health["fissile_inventory_min"], fissile_min)
+    health["protactinium_inventory_min"] = min(health["protactinium_inventory_min"], protactinium_min)
+    health["corrosion_index_min"] = min(health["corrosion_index_min"], corrosion_min)
+
+
+def _accumulate_device_extrema(
+    backend: ArrayBackend,
+    accumulators: dict[str, Any],
+    *,
+    power_fraction: Any,
+    temperatures: tuple[Any, ...],
+    corrosion_index: Any,
+    fissile_inventory_fraction: Any,
+    protactinium_inventory_fraction: Any,
+) -> dict[str, Any]:
+    """Fold this step's exact extrema into running device-side scalars.
+
+    Everything stays on the device, so a 3,601-step sweep pays one host
+    transfer for the whole trajectory instead of one per step per quantity.
+    """
+
+    def fold(key: str, value: Any, reducer: str) -> None:
+        take_max = reducer == "max"
+        reduced = backend.amax(value) if take_max else backend.amin(value)
+        current = accumulators.get(key)
+        if current is None:
+            accumulators[key] = reduced
+        elif take_max:
+            accumulators[key] = backend.maximum(current, reduced)
+        else:
+            accumulators[key] = backend.minimum(current, reduced)
+
+    fold("power_min", power_fraction, "min")
+    fold("power_max", power_fraction, "max")
+    for temperature in temperatures:
+        fold("temp_min", temperature, "min")
+        fold("temp_max", temperature, "max")
+    fold("corrosion_min", corrosion_index, "min")
+    fold("fissile_min", fissile_inventory_fraction, "min")
+    fold("protactinium_min", protactinium_inventory_fraction, "min")
+    return accumulators
 
 
 def _trajectory_checks(health: dict[str, Any]) -> dict[str, bool]:
@@ -1647,36 +1683,21 @@ def _vector_numerical_checks(
     *,
     metrics: dict[str, Any],
     trajectory_health: dict[str, Any],
-    power_fraction: Any,
-    fuel_temp_c: Any,
-    graphite_temp_c: Any,
-    coolant_temp_c: Any,
-    fissile_inventory_fraction: Any,
-    protactinium_inventory_fraction: Any,
-    corrosion_index: Any,
+    device_extrema: dict[str, Any],
     core_inventory: Any,
     segment_inventory: Any,
 ) -> dict[str, Any]:
-    min_temp = min(
-        backend.min_scalar(fuel_temp_c), backend.min_scalar(graphite_temp_c), backend.min_scalar(coolant_temp_c)
-    )
-    max_temp = max(
-        backend.max_scalar(fuel_temp_c), backend.max_scalar(graphite_temp_c), backend.max_scalar(coolant_temp_c)
-    )
-    # The vectorized loop records percentile bands rather than per-sample
-    # extrema, so fold the true final-step extrema in here.
-    trajectory_health["temperature_min_c"] = min(trajectory_health["temperature_min_c"], min_temp)
-    trajectory_health["temperature_max_c"] = max(trajectory_health["temperature_max_c"], max_temp)
-    trajectory_health["power_fraction_min"] = min(
-        trajectory_health["power_fraction_min"], backend.min_scalar(power_fraction)
-    )
-    trajectory_health["power_fraction_max"] = max(
-        trajectory_health["power_fraction_max"], backend.max_scalar(power_fraction)
-    )
-    trajectory_health["fissile_inventory_min"] = backend.min_scalar(fissile_inventory_fraction)
-    trajectory_health["protactinium_inventory_min"] = backend.min_scalar(protactinium_inventory_fraction)
-    trajectory_health["corrosion_index_min"] = min(
-        trajectory_health["corrosion_index_min"], backend.min_scalar(corrosion_index)
+    # The single host transfer for the whole trajectory: every extremum below
+    # was reduced on device, once per step, and is read exactly here.
+    _observe_trajectory_extrema(
+        trajectory_health,
+        power_min=backend.scalar(device_extrema["power_min"]),
+        power_max=backend.scalar(device_extrema["power_max"]),
+        temp_min=backend.scalar(device_extrema["temp_min"]),
+        temp_max=backend.scalar(device_extrema["temp_max"]),
+        fissile_min=backend.scalar(device_extrema["fissile_min"]),
+        protactinium_min=backend.scalar(device_extrema["protactinium_min"]),
+        corrosion_min=backend.scalar(device_extrema["corrosion_min"]),
     )
     checks = {
         "finite_metrics": all(

--- a/src/thorium_reactor/transient_sweep.py
+++ b/src/thorium_reactor/transient_sweep.py
@@ -4,6 +4,7 @@ import json
 import math
 import random
 import time
+from pathlib import Path
 from typing import Any
 
 from thorium_reactor.accelerators import (
@@ -12,6 +13,7 @@ from thorium_reactor.accelerators import (
     ArrayBackend,
     BackendUnavailable,
     backend_report_for_selection,
+    check_memory_budget,
     create_array_backend,
     resolve_runtime_backend,
 )
@@ -19,6 +21,7 @@ from thorium_reactor.capabilities import BALANCE_OF_PLANT, THERMAL_NETWORK, vali
 from thorium_reactor.chemistry import build_chemistry_assumptions
 from thorium_reactor.literature_models import build_property_uncertainty_summary
 from thorium_reactor.precursors import (
+    LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL,
     build_initial_precursor_state,
     normalize_loop_segments,
     precursor_group_summary,
@@ -38,6 +41,19 @@ from thorium_reactor.transient import (
 DEFAULT_TRANSIENT_SWEEP_MODEL = "reduced_order_transient_proxy_ensemble"
 DEFAULT_TRANSIENT_SWEEP_SAMPLES = 65_536
 MIN_TRANSIENT_SWEEP_SAMPLES = 32
+#: Largest ensemble a browser-launched sweep may request. Well above the point
+#: where GPU offload pays off (see accelerators.GPU_EFFICIENT_SAMPLE_FLOOR), and
+#: still under a gigabyte of device state in float32.
+MAX_TRANSIENT_SWEEP_SAMPLES = 4_194_304
+
+
+class NumericalHealthError(RuntimeError):
+    """Raised when the integrated ensemble fails its own numerical checks."""
+
+    def __init__(self, checks: dict[str, Any]) -> None:
+        failures = ", ".join(checks.get("failures", [])) or "unknown"
+        super().__init__(f"Transient sweep numerical checks failed: {failures}.")
+        self.checks = checks
 
 
 def run_transient_sweep_case(
@@ -68,7 +84,7 @@ def run_transient_sweep_case(
         payload["provenance"] = json.loads(json.dumps(provenance))
 
     transient_path = bundle.write_json("transient_sweep.json", payload)
-    summary["transient_sweep"] = transient_sweep_summary(payload, history_path=str(transient_path))
+    summary["transient_sweep"] = transient_sweep_summary(payload, history_path=_bundle_relative_path(transient_path))
     summary.setdefault("metrics", {})
     summary["metrics"]["transient_sweep_peak_power_fraction_p95"] = payload["metrics"]["peak_power_fraction_p95"]
     summary["metrics"]["transient_sweep_peak_fuel_temperature_c_p95"] = payload["metrics"][
@@ -111,16 +127,14 @@ def build_transient_sweep_payload(
         transient_config,
         property_uncertainty=property_uncertainty,
     )
+    sample_count = max(int(samples), MIN_TRANSIENT_SWEEP_SAMPLES)
     ensemble_definition = _build_ensemble_definition(
         uncertainty_model,
         scenario=scenario,
         seed=int(seed),
-        requested_samples=max(int(samples), MIN_TRANSIENT_SWEEP_SAMPLES),
+        requested_samples=sample_count,
     )
-    sample_count = max(int(samples), MIN_TRANSIENT_SWEEP_SAMPLES)
-    requested_backend = "auto" if backend == "auto" else backend
-    if prefer_gpu and backend == "auto":
-        requested_backend = "auto"
+    requested_backend = _resolve_requested_backend(backend, prefer_gpu=prefer_gpu)
 
     (
         history,
@@ -137,16 +151,22 @@ def build_transient_sweep_payload(
         chemistry=chemistry,
         samples=sample_count,
         seed=int(seed),
-        prefer_gpu=prefer_gpu,
         uncertainty_model=uncertainty_model,
         backend_name=requested_backend,
         dtype=dtype,
     )
 
+    if numerical_checks.get("status") != "ok":
+        # The ensemble did not pass its own checks. Callers must not be able to
+        # publish a bundle that quietly records "failed" next to its metrics.
+        raise NumericalHealthError(numerical_checks)
+
     payload = {
         "case": config.name,
         "model": DEFAULT_TRANSIENT_SWEEP_MODEL,
         "backend": backend_label,
+        "requested_backend": requested_backend,
+        "dtype": backend_report.get("details", {}).get("dtype") if backend_report.get("details") else dtype,
         "samples": sample_count,
         "seed": int(seed),
         "scenario": scenario,
@@ -168,6 +188,42 @@ def build_transient_sweep_payload(
     return payload
 
 
+def _resolve_requested_backend(backend: str, *, prefer_gpu: bool) -> str:
+    """Map the CLI/web backend request onto a concrete accelerator request.
+
+    ``--prefer-gpu`` is the deprecated spelling of ``--backend auto``. It only
+    means anything when no explicit backend was given: asking for
+    ``--backend numpy --prefer-gpu`` must keep numpy rather than silently
+    upgrading to the GPU, and asking for ``--prefer-gpu`` alone must not be a
+    no-op just because ``--backend`` happens to default to ``auto``.
+    """
+    requested = (backend or "auto").strip().lower()
+    if requested == "auto":
+        return "auto"
+    if prefer_gpu:
+        raise BackendUnavailable(
+            f"--prefer-gpu is the deprecated spelling of --backend auto and conflicts with "
+            f"--backend {requested}. Pass only one of them."
+        )
+    return requested
+
+
+def _bundle_relative_path(path: Any) -> str:
+    """Path recorded in the bundle, relative to the repository root.
+
+    Absolute host paths leak the machine layout into summary.json and report.md
+    and break the moment a bundle is copied or read from inside a container.
+    """
+    resolved = Path(path)
+    for parent in resolved.parents:
+        if parent.parent.name == "results" or parent.name == "results":
+            try:
+                return resolved.relative_to(parent.parent.parent).as_posix()
+            except ValueError:
+                break
+    return resolved.name
+
+
 def transient_sweep_summary(payload: dict[str, Any], *, history_path: str) -> dict[str, Any]:
     metrics = payload["metrics"]
     property_uncertainty = payload["property_uncertainty"]
@@ -175,6 +231,11 @@ def transient_sweep_summary(payload: dict[str, Any], *, history_path: str) -> di
         "status": "completed",
         "model": DEFAULT_TRANSIENT_SWEEP_MODEL,
         "backend": payload["backend"],
+        "requested_backend": payload.get("requested_backend"),
+        "device": (payload.get("backend_report") or {}).get("details", {}).get("device")
+        if (payload.get("backend_report") or {}).get("details")
+        else None,
+        "dtype": payload.get("dtype"),
         "samples": payload["samples"],
         "seed": payload["seed"],
         "scenario_name": payload["scenario"]["name"],
@@ -331,7 +392,6 @@ def _integrate_transient_ensemble(
     chemistry: dict[str, Any],
     samples: int,
     seed: int,
-    prefer_gpu: bool,
     uncertainty_model: dict[str, float],
     backend_name: str,
     dtype: str,
@@ -343,6 +403,7 @@ def _integrate_transient_ensemble(
         seed=seed,
     )
     if selection.selected == "python":
+        reference_backend = create_array_backend("python", dtype=selection.dtype, seed=seed)
         return _integrate_transient_ensemble_reference(
             baseline=baseline,
             scenario=scenario,
@@ -351,17 +412,29 @@ def _integrate_transient_ensemble(
             chemistry=chemistry,
             samples=samples,
             seed=seed,
-            prefer_gpu=prefer_gpu,
             uncertainty_model=uncertainty_model,
-            backend_report=backend_report_for_selection(selection, seed=seed),
+            backend_report=backend_report_for_selection(selection, seed=seed, backend=reference_backend),
         )
     if selection.selected not in VECTOR_ARRAY_BACKENDS:
         raise BackendUnavailable(f"Backend {selection.selected} cannot run the vectorized transient sweep.")
-    vector_backend = create_array_backend(selection.selected, dtype=dtype, seed=seed)
+    vector_backend = create_array_backend(selection.selected, dtype=selection.dtype, seed=seed)
     assert isinstance(vector_backend, ArrayBackend)
+    # Refuse an ensemble that cannot fit before spending minutes discovering it.
+    memory_budget = check_memory_budget(
+        vector_backend,
+        samples=samples,
+        dtype=selection.dtype,
+        groups=len(list(model_parameters["delayed_neutron_precursor_groups"])),
+        loop_segments=len(normalize_loop_segments(baseline.get("precursor_loop_segments"))),
+    )
     return _integrate_transient_ensemble_vectorized(
         array_backend=vector_backend,
-        backend_report=backend_report_for_selection(selection, seed=seed),
+        # Describe the instance we actually run on, rather than building a
+        # second device context purely to write the report.
+        backend_report={
+            **backend_report_for_selection(selection, seed=seed, backend=vector_backend),
+            "memory_budget": memory_budget,
+        },
         baseline=baseline,
         scenario=scenario,
         model_parameters=model_parameters,
@@ -382,11 +455,10 @@ def _integrate_transient_ensemble_reference(
     chemistry: dict[str, Any],
     samples: int,
     seed: int,
-    prefer_gpu: bool,
     uncertainty_model: dict[str, float],
     backend_report: dict[str, Any],
 ) -> tuple[list[dict[str, Any]], dict[str, Any], str, dict[str, Any], dict[str, Any], dict[str, Any]]:
-    integrate_start = time.perf_counter()
+    setup_start = time.perf_counter()
     backend = "python"
     perturbations = _build_perturbations(samples, seed, uncertainty_model)
 
@@ -500,7 +572,12 @@ def _integrate_transient_ensemble_reference(
     peak_power_fraction_max = 1.0
     peak_fuel_temperature_c_max = steady_fuel_temp_c
     peak_corrosion_index_max = float(chemistry_baseline.get("corrosion_index", 1.0))
+    trajectory_health = _new_trajectory_health()
 
+    # Timed from here so this matches the vectorized path, which also excludes
+    # perturbation build and precursor initialization from elapsed_s.
+    setup_elapsed_s = time.perf_counter() - setup_start
+    integrate_start = time.perf_counter()
     for step in range(step_count + 1):
         time_s = step * dt
         dt_days = dt / 86400.0
@@ -774,6 +851,19 @@ def _integrate_transient_ensemble_reference(
         peak_power_fraction_max = max(peak_power_fraction_max, max(power_fraction))
         peak_fuel_temperature_c_max = max(peak_fuel_temperature_c_max, max(fuel_temp_c))
         peak_corrosion_index_max = max(peak_corrosion_index_max, max(corrosion_index))
+        _observe_trajectory_health(
+            trajectory_health,
+            step=step,
+            time_s=time_s,
+            power_min=min(power_fraction),
+            power_max=max(power_fraction),
+            temp_min=min(min(fuel_temp_c), min(graphite_temp_c), min(coolant_temp_c)),
+            temp_max=max(max(fuel_temp_c), max(graphite_temp_c), max(coolant_temp_c)),
+            fissile_min=min(fissile_inventory_fraction),
+            protactinium_min=min(protactinium_inventory_fraction),
+            corrosion_min=min(corrosion_index),
+            history_row=history[-1],
+        )
 
     metrics = {
         "duration_s": _round_float(duration_s),
@@ -797,23 +887,17 @@ def _integrate_transient_ensemble_reference(
         "peak_corrosion_index_p95": _round_float(max(item["corrosion_index_p95"] for item in history)),
         "peak_corrosion_index_max": _round_float(peak_corrosion_index_max),
     }
-    if prefer_gpu:
-        metrics["requested_gpu_backend"] = True
     elapsed_s = time.perf_counter() - integrate_start
     runtime_performance = {
         "elapsed_s": _round_float(elapsed_s),
+        "setup_s": _round_float(setup_elapsed_s),
         "sample_steps_per_s": _round_float((samples * max(len(history), 1)) / max(elapsed_s, 1.0e-12)),
         "backend_memory_allocated_bytes": None,
+        "backend_peak_memory_allocated_bytes": None,
     }
     numerical_checks = _reference_numerical_checks(
         metrics=metrics,
-        power_fraction=power_fraction,
-        fuel_temp_c=fuel_temp_c,
-        graphite_temp_c=graphite_temp_c,
-        coolant_temp_c=coolant_temp_c,
-        fissile_inventory_fraction=fissile_inventory_fraction,
-        protactinium_inventory_fraction=protactinium_inventory_fraction,
-        corrosion_index=corrosion_index,
+        trajectory_health=trajectory_health,
         precursor_states=precursor_states,
     )
     metrics["numerical_health"] = numerical_checks["status"]
@@ -836,6 +920,8 @@ def _integrate_transient_ensemble_vectorized(
     uncertainty_model: dict[str, float],
 ) -> tuple[list[dict[str, Any]], dict[str, Any], str, dict[str, Any], dict[str, Any], dict[str, Any]]:
     backend = array_backend
+    backend.reset_peak_memory_stats()
+    setup_start = time.perf_counter()
     perturbations = _build_backend_perturbations(backend, samples, seed, uncertainty_model)
 
     dt = max(float(scenario["time_step_s"]), 0.05)
@@ -887,7 +973,16 @@ def _integrate_transient_ensemble_vectorized(
     )
 
     groups = list(model_parameters["delayed_neutron_precursor_groups"])
-    loop_segments = normalize_loop_segments(baseline.get("precursor_loop_segments"))
+    # Honour the configured precursor transport model, as the reference
+    # integrator does. The two-region model is algebraically the single-segment
+    # case of the segmented model -- same steady state, same implicit step -- so
+    # collapsing the segment list is enough to reproduce it exactly.
+    transport_model = str(model_parameters["precursor_transport_model"])
+    loop_segments = (
+        normalize_loop_segments(baseline.get("precursor_loop_segments"))
+        if transport_model == LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL
+        else normalize_loop_segments(None)
+    )
     initial_flow_fraction = backend.clip(perturbations["flow_scale"], 0.05, 1.5)
     initial_cleanup_rate_s = float(baseline["cleanup_removal_efficiency"]) * backend.clip(
         perturbations["cleanup_scale"], 0.0, 2.5
@@ -926,7 +1021,10 @@ def _integrate_transient_ensemble_vectorized(
         1.0e-12,
     )
 
+    trajectory_health = _new_trajectory_health()
+
     backend.synchronize()
+    setup_elapsed_s = time.perf_counter() - setup_start
     integrate_start = time.perf_counter()
     for step in range(step_count + 1):
         time_s = step * dt
@@ -1118,11 +1216,24 @@ def _integrate_transient_ensemble_vectorized(
             backend, power_fraction, power_target, dt, float(model_parameters["power_response_time_s"])
         )
 
-        power_band = backend.percentiles(power_fraction, (0.05, 0.50, 0.95))
-        fuel_band = backend.percentiles(fuel_temp_c, (0.05, 0.50, 0.95))
-        reactivity_band = backend.percentiles(final_total_reactivity_pcm, (0.05, 0.50, 0.95))
-        corrosion_band = backend.percentiles(corrosion_index, (0.05, 0.50, 0.95))
-        core_delayed_source_band = backend.percentiles(core_delayed_neutron_source_fraction, (0.05, 0.50, 0.95))
+        # One host transfer for all five series, rather than five separate
+        # device synchronizations per time step.
+        (
+            power_band,
+            fuel_band,
+            reactivity_band,
+            corrosion_band,
+            core_delayed_source_band,
+        ) = backend.percentiles_batch(
+            [
+                power_fraction,
+                fuel_temp_c,
+                final_total_reactivity_pcm,
+                corrosion_index,
+                core_delayed_neutron_source_fraction,
+            ],
+            (0.05, 0.50, 0.95),
+        )
         history.append(
             {
                 "time_s": _round_float(time_s),
@@ -1146,6 +1257,25 @@ def _integrate_transient_ensemble_vectorized(
         peak_power_fraction_max = max(peak_power_fraction_max, backend.max_scalar(power_fraction))
         peak_fuel_temperature_c_max = max(peak_fuel_temperature_c_max, backend.max_scalar(fuel_temp_c))
         peak_corrosion_index_max = max(peak_corrosion_index_max, backend.max_scalar(corrosion_index))
+        # Percentile bands already crossed to the host this step, so the
+        # trajectory health screen costs no extra synchronization.
+        _observe_trajectory_health(
+            trajectory_health,
+            step=step,
+            time_s=time_s,
+            # Bands, not per-sample extrema: reading true min/max every step
+            # would add two device synchronizations per step for a quantity the
+            # final-step check already covers exactly. The band still catches a
+            # trajectory that leaves the physical envelope.
+            power_min=power_band[0],
+            power_max=peak_power_fraction_max,
+            temp_min=fuel_band[0],
+            temp_max=peak_fuel_temperature_c_max,
+            fissile_min=None,
+            protactinium_min=None,
+            corrosion_min=corrosion_band[0],
+            history_row=history[-1],
+        )
 
     backend.synchronize()
     elapsed_s = time.perf_counter() - integrate_start
@@ -1173,12 +1303,17 @@ def _integrate_transient_ensemble_vectorized(
     }
     runtime_performance = {
         "elapsed_s": _round_float(elapsed_s),
+        "setup_s": _round_float(setup_elapsed_s),
         "sample_steps_per_s": _round_float((samples * (step_count + 1)) / max(elapsed_s, 1.0e-12)),
         "backend_memory_allocated_bytes": backend.memory_allocated_bytes(),
+        # Peak is what a VRAM budget has to cover; current allocation
+        # understates it by roughly 2x once transients are freed.
+        "backend_peak_memory_allocated_bytes": backend.max_memory_allocated_bytes(),
     }
     numerical_checks = _vector_numerical_checks(
         backend,
         metrics=metrics,
+        trajectory_health=trajectory_health,
         power_fraction=power_fraction,
         fuel_temp_c=fuel_temp_c,
         graphite_temp_c=graphite_temp_c,
@@ -1201,9 +1336,15 @@ def _build_backend_perturbations(
     seed: int,
     uncertainty_model: dict[str, float],
 ) -> dict[str, Any]:
-    # Use the reference RNG stream so CPU/GPU benchmarks compare the same ensemble.
-    raw = _build_perturbations(samples, seed, uncertainty_model)
-    return {key: backend.asarray(value) for key, value in raw.items()}
+    """Build the ensemble perturbations for a vector backend.
+
+    Uses the same ``random.Random`` stream as the reference path so CPU and GPU
+    runs compare the same ensemble, but materializes each parameter one at a
+    time and hands it straight to the device. Building all eleven Python lists
+    first costs roughly 30 bytes per float object -- about 5 GB of host RAM at
+    16.7M samples, which is enough to destabilize the machine.
+    """
+    return {key: backend.asarray(values) for key, values in _iter_perturbation_arrays(samples, seed, uncertainty_model)}
 
 
 def _first_order_step_backend(backend: ArrayBackend, current: Any, target: Any, dt: float, tau_s: float) -> Any:
@@ -1295,8 +1436,9 @@ def _step_precursors_vectorized(
                     + dt * previous_rate * affine_constants[-1]
                 )
                 prior_slope = dt * previous_rate * affine_slopes[-1]
-            affine_constants.append(prior_constant / backend.maximum(diagonal, 1.0e-18))
-            affine_slopes.append(prior_slope / backend.maximum(diagonal, 1.0e-18))
+            safe_diagonal = backend.maximum(diagonal, 1.0e-18)
+            affine_constants.append(prior_constant / safe_diagonal)
+            affine_slopes.append(prior_slope / safe_diagonal)
         core_diagonal = 1.0 + dt * (core_transport_rate_s + decay)
         rhs_core = backend.maximum(core_inventory[:, group_index], 0.0) + dt * source_rate
         return_rate = dt * segment_rates[-1]
@@ -1382,16 +1524,100 @@ def _annotate_vectorized_precursor_baseline(
     baseline["precursor_loop_segment_summary"] = segment_summaries
 
 
+#: Shared non-negativity tolerance. The vectorized path may run in float32 and
+#: the reference in float64, but "did an inventory go negative" must mean the
+#: same thing on both, or a parity comparison of the checks is meaningless.
+PRECURSOR_NON_NEGATIVE_TOLERANCE = 1.0e-7
+POWER_FRACTION_CEILING = 10.0
+TEMPERATURE_CEILING_C = 2500.0
+
+
+def _new_trajectory_health() -> dict[str, Any]:
+    return {
+        "power_fraction_min": math.inf,
+        "power_fraction_max": -math.inf,
+        "temperature_min_c": math.inf,
+        "temperature_max_c": -math.inf,
+        "fissile_inventory_min": math.inf,
+        "protactinium_inventory_min": math.inf,
+        "corrosion_index_min": math.inf,
+        "non_finite_steps": [],
+        "steps_observed": 0,
+    }
+
+
+def _observe_trajectory_health(
+    health: dict[str, Any],
+    *,
+    step: int,
+    time_s: float,
+    power_min: float,
+    power_max: float,
+    temp_min: float,
+    temp_max: float,
+    fissile_min: float | None,
+    protactinium_min: float | None,
+    corrosion_min: float,
+    history_row: dict[str, Any],
+) -> None:
+    """Screen every recorded step, not just the last one.
+
+    A transient that goes non-finite or negative mid-flight and recovers by the
+    final step used to pass silently; the sweep is a stress-test envelope, so an
+    excursion anywhere in the trajectory is exactly what we need to catch.
+    """
+    health["steps_observed"] += 1
+    health["power_fraction_min"] = min(health["power_fraction_min"], power_min)
+    health["power_fraction_max"] = max(health["power_fraction_max"], power_max)
+    health["temperature_min_c"] = min(health["temperature_min_c"], temp_min)
+    health["temperature_max_c"] = max(health["temperature_max_c"], temp_max)
+    if fissile_min is not None:
+        health["fissile_inventory_min"] = min(health["fissile_inventory_min"], fissile_min)
+    if protactinium_min is not None:
+        health["protactinium_inventory_min"] = min(health["protactinium_inventory_min"], protactinium_min)
+    health["corrosion_index_min"] = min(health["corrosion_index_min"], corrosion_min)
+    if len(health["non_finite_steps"]) < 8 and not all(
+        math.isfinite(float(value)) for value in history_row.values() if isinstance(value, (int, float))
+    ):
+        health["non_finite_steps"].append({"step": step, "time_s": _round_float(time_s)})
+
+
+def _trajectory_checks(health: dict[str, Any]) -> dict[str, bool]:
+    observed = health["steps_observed"] > 0
+    return {
+        "history_finite_at_every_step": not health["non_finite_steps"],
+        "power_fraction_bounded_over_trajectory": observed
+        and health["power_fraction_min"] >= 0.0
+        and health["power_fraction_max"] <= POWER_FRACTION_CEILING,
+        "temperatures_bounded_over_trajectory": observed
+        and health["temperature_min_c"] > 0.0
+        and health["temperature_max_c"] < TEMPERATURE_CEILING_C,
+        "corrosion_index_positive_over_trajectory": observed and health["corrosion_index_min"] > 0.0,
+    }
+
+
+def _finalize_numerical_checks(
+    checks: dict[str, bool], health: dict[str, Any], *, extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    resolved = {**checks, **_trajectory_checks(health)}
+    return {
+        "status": "ok" if all(resolved.values()) else "failed",
+        "checks": resolved,
+        "failures": [key for key, value in resolved.items() if not value],
+        "trajectory": {
+            key: (None if value in (math.inf, -math.inf) else _round_float(value))
+            if isinstance(value, float)
+            else value
+            for key, value in health.items()
+        },
+        **(extra or {}),
+    }
+
+
 def _reference_numerical_checks(
     *,
     metrics: dict[str, Any],
-    power_fraction: list[float],
-    fuel_temp_c: list[float],
-    graphite_temp_c: list[float],
-    coolant_temp_c: list[float],
-    fissile_inventory_fraction: list[float],
-    protactinium_inventory_fraction: list[float],
-    corrosion_index: list[float],
+    trajectory_health: dict[str, Any],
     precursor_states: list[dict[str, Any]],
 ) -> dict[str, Any]:
     precursor_min = min(
@@ -1409,25 +1635,18 @@ def _reference_numerical_checks(
         "finite_metrics": all(
             math.isfinite(float(value)) for value in metrics.values() if isinstance(value, (int, float))
         ),
-        "power_fraction_bounded": min(power_fraction) >= 0.0 and max(power_fraction) <= 10.0,
-        "temperatures_bounded": min(fuel_temp_c + graphite_temp_c + coolant_temp_c) > 0.0
-        and max(fuel_temp_c + graphite_temp_c + coolant_temp_c) < 2500.0,
-        "precursor_inventory_non_negative": precursor_min >= -1.0e-9,
-        "fissile_inventory_non_negative": min(fissile_inventory_fraction) >= 0.0,
-        "protactinium_inventory_non_negative": min(protactinium_inventory_fraction) >= 0.0,
-        "corrosion_index_positive": min(corrosion_index) > 0.0,
+        "precursor_inventory_non_negative": precursor_min >= -PRECURSOR_NON_NEGATIVE_TOLERANCE,
+        "fissile_inventory_non_negative": trajectory_health["fissile_inventory_min"] >= 0.0,
+        "protactinium_inventory_non_negative": trajectory_health["protactinium_inventory_min"] >= 0.0,
     }
-    return {
-        "status": "ok" if all(checks.values()) else "failed",
-        "checks": checks,
-        "failures": [key for key, value in checks.items() if not value],
-    }
+    return _finalize_numerical_checks(checks, trajectory_health)
 
 
 def _vector_numerical_checks(
     backend: ArrayBackend,
     *,
     metrics: dict[str, Any],
+    trajectory_health: dict[str, Any],
     power_fraction: Any,
     fuel_temp_c: Any,
     graphite_temp_c: Any,
@@ -1444,98 +1663,68 @@ def _vector_numerical_checks(
     max_temp = max(
         backend.max_scalar(fuel_temp_c), backend.max_scalar(graphite_temp_c), backend.max_scalar(coolant_temp_c)
     )
+    # The vectorized loop records percentile bands rather than per-sample
+    # extrema, so fold the true final-step extrema in here.
+    trajectory_health["temperature_min_c"] = min(trajectory_health["temperature_min_c"], min_temp)
+    trajectory_health["temperature_max_c"] = max(trajectory_health["temperature_max_c"], max_temp)
+    trajectory_health["power_fraction_min"] = min(
+        trajectory_health["power_fraction_min"], backend.min_scalar(power_fraction)
+    )
+    trajectory_health["power_fraction_max"] = max(
+        trajectory_health["power_fraction_max"], backend.max_scalar(power_fraction)
+    )
+    trajectory_health["fissile_inventory_min"] = backend.min_scalar(fissile_inventory_fraction)
+    trajectory_health["protactinium_inventory_min"] = backend.min_scalar(protactinium_inventory_fraction)
+    trajectory_health["corrosion_index_min"] = min(
+        trajectory_health["corrosion_index_min"], backend.min_scalar(corrosion_index)
+    )
     checks = {
         "finite_metrics": all(
             math.isfinite(float(value)) for value in metrics.values() if isinstance(value, (int, float))
         ),
-        "power_fraction_bounded": backend.min_scalar(power_fraction) >= 0.0
-        and backend.max_scalar(power_fraction) <= 10.0,
-        "temperatures_bounded": min_temp > 0.0 and max_temp < 2500.0,
         "precursor_inventory_non_negative": min(
             backend.min_scalar(core_inventory), backend.min_scalar(segment_inventory)
         )
-        >= -1.0e-7,
-        "fissile_inventory_non_negative": backend.min_scalar(fissile_inventory_fraction) >= 0.0,
-        "protactinium_inventory_non_negative": backend.min_scalar(protactinium_inventory_fraction) >= 0.0,
-        "corrosion_index_positive": backend.min_scalar(corrosion_index) > 0.0,
+        >= -PRECURSOR_NON_NEGATIVE_TOLERANCE,
+        "fissile_inventory_non_negative": trajectory_health["fissile_inventory_min"] >= 0.0,
+        "protactinium_inventory_non_negative": trajectory_health["protactinium_inventory_min"] >= 0.0,
     }
-    return {
-        "status": "ok" if all(checks.values()) else "failed",
-        "checks": checks,
-        "failures": [key for key, value in checks.items() if not value],
-    }
+    return _finalize_numerical_checks(checks, trajectory_health)
+
+
+#: The ensemble parameters, in the exact order they consume the RNG stream.
+#: Both the reference path and the vector path walk this list, so the two
+#: always draw the identical ensemble for a given seed. Order is load-bearing:
+#: changing it changes every result.
+PERTURBATION_SPECS: tuple[tuple[str, str, float, float, float], ...] = (
+    ("event_reactivity_scale", "event_reactivity_sigma_fraction", 1.0, 0.55, 1.55),
+    ("flow_scale", "flow_sigma_fraction", 1.0, 0.65, 1.45),
+    ("heat_sink_scale", "heat_sink_sigma_fraction", 1.0, 0.6, 1.45),
+    ("cleanup_scale", "cleanup_sigma_fraction", 1.0, 0.6, 1.6),
+    ("temperature_feedback_scale", "temperature_feedback_sigma_fraction", 1.0, 0.8, 1.2),
+    ("precursor_worth_scale", "precursor_worth_sigma_fraction", 1.0, 0.75, 1.25),
+    ("xenon_worth_scale", "xenon_worth_sigma_fraction", 1.0, 0.7, 1.3),
+    ("sink_temp_bias_c", "sink_offset_sigma_c", 0.0, -math.inf, math.inf),
+    ("redox_bias_ev", "redox_setpoint_sigma_ev", 0.0, -math.inf, math.inf),
+    ("impurity_ingress_scale", "impurity_ingress_sigma_fraction", 1.0, 0.5, 1.8),
+    ("gas_stripping_scale", "gas_stripping_sigma_fraction", 1.0, 0.85, 1.15),
+)
+
+
+def _iter_perturbation_arrays(samples: int, seed: int, uncertainty_model: dict[str, float]) -> Any:
+    """Yield ``(name, values)`` one parameter at a time, in RNG order.
+
+    Streaming keeps only one parameter's worth of samples alive at a time
+    instead of all eleven, which matters at large ensembles.
+    """
+    rng = random.Random(seed)
+    for name, sigma_key, mean, lower, upper in PERTURBATION_SPECS:
+        sigma = uncertainty_model[sigma_key]
+        yield name, [_clip_value(float(rng.gauss(mean, sigma)), lower, upper) for _ in range(samples)]
 
 
 def _build_perturbations(samples: int, seed: int, uncertainty_model: dict[str, float]) -> dict[str, list[float]]:
-    rng = random.Random(seed)
-    return {
-        "event_reactivity_scale": _bounded_normal(
-            rng, samples, mean=1.0, sigma=uncertainty_model["event_reactivity_sigma_fraction"], lower=0.55, upper=1.55
-        ),
-        "flow_scale": _bounded_normal(
-            rng, samples, mean=1.0, sigma=uncertainty_model["flow_sigma_fraction"], lower=0.65, upper=1.45
-        ),
-        "heat_sink_scale": _bounded_normal(
-            rng, samples, mean=1.0, sigma=uncertainty_model["heat_sink_sigma_fraction"], lower=0.6, upper=1.45
-        ),
-        "cleanup_scale": _bounded_normal(
-            rng, samples, mean=1.0, sigma=uncertainty_model["cleanup_sigma_fraction"], lower=0.6, upper=1.6
-        ),
-        "temperature_feedback_scale": _bounded_normal(
-            rng,
-            samples,
-            mean=1.0,
-            sigma=uncertainty_model["temperature_feedback_sigma_fraction"],
-            lower=0.8,
-            upper=1.2,
-        ),
-        "precursor_worth_scale": _bounded_normal(
-            rng,
-            samples,
-            mean=1.0,
-            sigma=uncertainty_model["precursor_worth_sigma_fraction"],
-            lower=0.75,
-            upper=1.25,
-        ),
-        "xenon_worth_scale": _bounded_normal(
-            rng,
-            samples,
-            mean=1.0,
-            sigma=uncertainty_model["xenon_worth_sigma_fraction"],
-            lower=0.7,
-            upper=1.3,
-        ),
-        "sink_temp_bias_c": [float(rng.gauss(0.0, uncertainty_model["sink_offset_sigma_c"])) for _ in range(samples)],
-        "redox_bias_ev": [float(rng.gauss(0.0, uncertainty_model["redox_setpoint_sigma_ev"])) for _ in range(samples)],
-        "impurity_ingress_scale": _bounded_normal(
-            rng,
-            samples,
-            mean=1.0,
-            sigma=uncertainty_model["impurity_ingress_sigma_fraction"],
-            lower=0.5,
-            upper=1.8,
-        ),
-        "gas_stripping_scale": _bounded_normal(
-            rng,
-            samples,
-            mean=1.0,
-            sigma=uncertainty_model["gas_stripping_sigma_fraction"],
-            lower=0.85,
-            upper=1.15,
-        ),
-    }
-
-
-def _bounded_normal(
-    rng: random.Random,
-    samples: int,
-    *,
-    mean: float,
-    sigma: float,
-    lower: float,
-    upper: float,
-) -> list[float]:
-    return [_clip_value(float(rng.gauss(mean, sigma)), lower, upper) for _ in range(samples)]
+    return dict(_iter_perturbation_arrays(samples, seed, uncertainty_model))
 
 
 def _first_order_step_array(

--- a/src/thorium_reactor/web/jobs.py
+++ b/src/thorium_reactor/web/jobs.py
@@ -176,9 +176,23 @@ def build_cli_command(draft: SimulationDraft, phase: str) -> list[str]:
         if draft.scenario:
             command.extend(["--scenario", draft.scenario])
         command.extend(["--samples", str(draft.sweep_samples), "--seed", str(draft.sweep_seed)])
-        if draft.prefer_gpu:
-            command.append("--prefer-gpu")
+        # Pass the backend explicitly. The old code sent --prefer-gpu, which is
+        # an alias for the "auto" that --backend already defaults to, so the
+        # browser's GPU control selected nothing at all.
+        command.extend(["--backend", resolve_draft_backend(draft), "--dtype", draft.sweep_dtype])
     return command
+
+
+def resolve_draft_backend(draft: SimulationDraft) -> str:
+    """The backend a draft asks for, honouring the deprecated ``prefer_gpu``.
+
+    ``sweep_backend`` wins whenever it is explicit. ``prefer_gpu`` only still
+    speaks for drafts that left the backend at "auto", so an old client that
+    unchecks it gets the CPU path it asked for instead of being ignored.
+    """
+    if draft.sweep_backend != "auto":
+        return draft.sweep_backend
+    return "auto" if draft.prefer_gpu else "numpy"
 
 
 def phase_timeout_seconds(phase: str) -> float:
@@ -225,7 +239,18 @@ def append_event(
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    """Write atomically.
+
+    A reader that catches this file mid-write sees invalid JSON, and the API's
+    read path falls back to inferring status from which files exist -- which
+    reports "completed" as soon as summary.json is present, long before a
+    multi-phase run is done. That torn read ends the SSE stream and detaches the
+    UI from a job that is still running, so the write must never be observable
+    in a partial state.
+    """
+    temporary = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(temporary, path)
 
 
 def is_terminal(status: str) -> bool:

--- a/src/thorium_reactor/web/repository.py
+++ b/src/thorium_reactor/web/repository.py
@@ -8,6 +8,7 @@ import mimetypes
 import re
 import shutil
 import tempfile
+import time
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
@@ -222,17 +223,10 @@ class WebRepository:
         run_dir = self._run_dir(case_name, run_id)
         if not run_dir.exists():
             raise FileNotFoundError(f"Run '{run_id}' for case '{case_name}' was not found.")
-        status_path = run_dir / "job_status.json"
-        status_payload = read_json(status_path, {})
+        status_payload = read_status_payload(run_dir)
         status = status_payload.get("status") if isinstance(status_payload, Mapping) else None
         if status:
             return str(status)
-        if status_path.exists():
-            # The file is the authority for a job-managed run. If it exists but
-            # did not parse, treat the run as still in flight rather than
-            # inferring "completed" from artifacts an earlier phase wrote --
-            # that would close the event stream on a job that is still running.
-            return "running"
         return infer_status_from_files(run_dir)
 
     def list_docs(self) -> list[DocSummary]:
@@ -1415,6 +1409,25 @@ def utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+def read_status_payload(run_dir: Path) -> Any:
+    """Read job_status.json, tolerating a write that is in flight.
+
+    Writes are atomic, but a reader on a filesystem without atomic rename
+    semantics can still catch a partial file. One retry absorbs that; a file
+    that stays unparseable is genuinely corrupt, so we fall through to
+    inference rather than reporting the run live forever and leaving the event
+    stream open.
+    """
+    path = run_dir / "job_status.json"
+    if not path.exists():
+        return {}
+    payload = read_json(path, None)
+    if payload is None:
+        time.sleep(0.05)
+        payload = read_json(path, None)
+    return payload if payload is not None else {}
+
+
 def _coerce_progress(value: Any) -> float | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
@@ -1536,6 +1549,12 @@ def infer_status(run_dir: Path, summary: Mapping[str, Any], validation: Mapping[
 
 
 def infer_status_from_files(run_dir: Path) -> str:
+    # The stage manifest is the record of what actually happened. A CLI stage
+    # that raised (a sweep failing its numerical checks, say) leaves the
+    # summary.json an earlier stage wrote, which would otherwise read as a
+    # clean success.
+    if stage_manifest_last_status(run_dir) == "failed":
+        return "failed"
     if (
         (run_dir / "summary.json").exists()
         or (run_dir / "validation.json").exists()
@@ -1545,6 +1564,16 @@ def infer_status_from_files(run_dir: Path) -> str:
     if (run_dir / "build_manifest.json").exists():
         return "built"
     return "unknown"
+
+
+def stage_manifest_last_status(run_dir: Path) -> str | None:
+    """Status of the most recent recorded stage, or None if there is no manifest."""
+    manifest = read_json(run_dir / "stage_manifest.json", {})
+    stages = manifest.get("stages") if isinstance(manifest, Mapping) else None
+    if not isinstance(stages, list) or not stages:
+        return None
+    last = stages[-1]
+    return str(last.get("status")) if isinstance(last, Mapping) and last.get("status") else None
 
 
 def is_viewable_geometry_artifact_path(value: Any) -> bool:

--- a/src/thorium_reactor/web/repository.py
+++ b/src/thorium_reactor/web/repository.py
@@ -222,9 +222,18 @@ class WebRepository:
         run_dir = self._run_dir(case_name, run_id)
         if not run_dir.exists():
             raise FileNotFoundError(f"Run '{run_id}' for case '{case_name}' was not found.")
-        status_payload = read_json(run_dir / "job_status.json", {})
+        status_path = run_dir / "job_status.json"
+        status_payload = read_json(status_path, {})
         status = status_payload.get("status") if isinstance(status_payload, Mapping) else None
-        return str(status) if status else infer_status_from_files(run_dir)
+        if status:
+            return str(status)
+        if status_path.exists():
+            # The file is the authority for a job-managed run. If it exists but
+            # did not parse, treat the run as still in flight rather than
+            # inferring "completed" from artifacts an earlier phase wrote --
+            # that would close the event stream on a job that is still running.
+            return "running"
+        return infer_status_from_files(run_dir)
 
     def list_docs(self) -> list[DocSummary]:
         docs: list[DocSummary] = []
@@ -312,6 +321,7 @@ class WebRepository:
             artifacts=self._artifacts_for_run(safe_case_name, safe_run_id, run_dir),
             output_sections=self._output_sections(summary, validation),
             latest_event=events[-1] if events else None,
+            progress=_coerce_progress(status_payload.get("progress")),
         )
 
     def _run_summary_record(self, case_name: str, run_id: str, run_dir: Path) -> RunRecord:
@@ -331,6 +341,7 @@ class WebRepository:
             finished_at=status_payload.get("finished_at"),
             metrics=metrics if isinstance(metrics, dict) else {},
             artifacts=self._summary_artifacts_for_run(safe_case_name, safe_run_id, run_dir),
+            progress=_coerce_progress(status_payload.get("progress")),
         )
 
     def _output_sections(self, summary: Any, validation: Any) -> list[OutputSection]:
@@ -657,9 +668,14 @@ class WebRepository:
         performance = as_mapping(sweep.get("runtime_performance"))
         checks = as_mapping(sweep.get("numerical_checks"))
         backend_report = as_mapping(sweep.get("backend_report"))
+        details = as_mapping(backend_report.get("details"))
         metrics = output_metrics(
             ("Samples", sweep.get("samples"), "count", "number"),
             ("Backend", first_present(sweep.get("backend"), backend_report.get("selected")), None, "text"),
+            # Which device did the work, and at what precision. Without these a
+            # reader cannot tell a GPU run from a CPU run in the browser.
+            ("Device", first_present(sweep.get("device"), details.get("device")), None, "text"),
+            ("Precision", first_present(sweep.get("dtype"), details.get("dtype")), None, "text"),
             ("Peak power p95", sweep.get("peak_power_fraction_p95"), "fraction", "number"),
             ("Peak power max", sweep.get("peak_power_fraction_max"), "fraction", "number"),
             ("Final power p50", sweep.get("final_power_fraction_p50"), "fraction", "number"),
@@ -672,7 +688,17 @@ class WebRepository:
         )
         notes = []
         if checks.get("status"):
-            notes.append(f"Numerical checks: {checks['status']}")
+            failures = checks.get("failures") or []
+            notes.append(
+                f"Numerical checks: {checks['status']}"
+                + (f" ({', '.join(str(item) for item in failures)})" if failures else "")
+            )
+        requested = sweep.get("requested_backend") or backend_report.get("requested")
+        selected = first_present(sweep.get("backend"), backend_report.get("selected"))
+        if requested and selected and requested != selected and requested != "auto":
+            # A run that asked for one backend and got another must say so
+            # rather than presenting the substitute as what was requested.
+            notes.append(f"Requested {requested}, ran on {selected}.")
         if backend_report.get("reason"):
             notes.append(str(backend_report["reason"]))
         self._append_section(
@@ -1387,6 +1413,12 @@ def normalize_artifact_path(artifact_path: str) -> Path:
 
 def utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_progress(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return max(0.0, min(1.0, float(value)))
 
 
 def read_json(path: Path, fallback: Any) -> Any:

--- a/src/thorium_reactor/web/schemas.py
+++ b/src/thorium_reactor/web/schemas.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from thorium_reactor.transient_sweep import DEFAULT_TRANSIENT_SWEEP_SAMPLES
+from thorium_reactor.transient_sweep import DEFAULT_TRANSIENT_SWEEP_SAMPLES, MAX_TRANSIENT_SWEEP_SAMPLES
 
 
 class ArtifactRef(BaseModel):
@@ -59,6 +59,9 @@ class RunRecord(BaseModel):
     artifacts: list[ArtifactRef] = Field(default_factory=list)
     output_sections: list[OutputSection] = Field(default_factory=list)
     latest_event: RunEvent | None = None
+    #: Job progress from the run's own status file. The UI must not read
+    #: progress off the latest event, because log events carry none.
+    progress: float | None = None
 
 
 class EditableParameter(BaseModel):
@@ -89,6 +92,10 @@ class CaseDetail(CaseSummary):
     benchmark_path: str | None = None
 
 
+SWEEP_BACKENDS = ("auto", "numpy", "torch-cpu", "torch-xpu")
+SWEEP_DTYPES = ("float32", "float64")
+
+
 class SimulationDraft(BaseModel):
     case_name: str
     run_id: str | None = None
@@ -96,8 +103,17 @@ class SimulationDraft(BaseModel):
     patch: dict[str, Any] = Field(default_factory=dict)
     phases: list[str] = Field(default_factory=lambda: ["run", "validate", "report"])
     scenario: str | None = None
-    sweep_samples: int = Field(default=DEFAULT_TRANSIENT_SWEEP_SAMPLES, ge=1, le=65536)
+    # The old 65,536 ceiling sat exactly where GPU offload stops paying for
+    # itself, so a browser sweep could never reach the regime the accelerator
+    # exists for. The bound now tracks what the device can actually hold.
+    sweep_samples: int = Field(default=DEFAULT_TRANSIENT_SWEEP_SAMPLES, ge=1, le=MAX_TRANSIENT_SWEEP_SAMPLES)
     sweep_seed: int = Field(default=42, ge=0, le=4294967295)
+    # "python" is deliberately absent: the pure-Python reference integrator is
+    # orders of magnitude slower and would blow the job budget from a browser.
+    sweep_backend: Literal["auto", "numpy", "torch-cpu", "torch-xpu"] = "auto"
+    sweep_dtype: Literal["float32", "float64"] = "float32"
+    #: Deprecated. Retained so existing clients keep working; ``sweep_backend``
+    #: is the control that actually selects a backend.
     prefer_gpu: bool = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,49 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from thorium_reactor.msd_tp import clear_database_cache
+
+
+def build_minimal_summary() -> dict[str, Any]:
+    """The smallest summary a transient sweep will accept.
+
+    Lives here rather than in a test module because test modules are imported
+    by basename and are not a package -- importing one from another works under
+    some pytest invocations and fails under others.
+    """
+    return {
+        "bop": {"thermal_power_mw": 8.0},
+        "flow": {
+            "reduced_order": {
+                "active_flow": {
+                    "representative_residence_time_s": 0.85,
+                    "total_volumetric_flow_m3_s": 0.014,
+                }
+            }
+        },
+        "primary_system": {
+            "thermal_profile": {
+                "estimated_hot_leg_temp_c": 690.0,
+                "estimated_cold_leg_temp_c": 555.0,
+            },
+            "inventory": {
+                "fuel_salt": {"total_m3": 0.092},
+                "coolant_salt": {"net_pool_inventory_m3": 11.4},
+            },
+        },
+        "fuel_cycle": {
+            "cleanup_turnover_hours": 240.0,
+            "cleanup_turnover_days": 10.0,
+            "cleanup_removal_efficiency": 0.78,
+        },
+    }
+
+
+@pytest.fixture
+def minimal_summary() -> dict[str, Any]:
+    return build_minimal_summary()
 
 
 @pytest.fixture

--- a/tests/test_gpu_backend_regressions.py
+++ b/tests/test_gpu_backend_regressions.py
@@ -1,0 +1,387 @@
+"""Regressions for the accelerated transient-sweep path.
+
+Every test here pins a defect found by auditing a real end-to-end GPU run of
+``flagship_grid_msr`` on an Intel Arc Pro B70. The XPU-specific ones skip when
+no device is present; everything else runs anywhere.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.test_transient_sweep import _minimal_summary
+from thorium_reactor import accelerators
+from thorium_reactor.accelerators import (
+    BackendUnavailable,
+    create_array_backend,
+    estimate_state_bytes,
+    resolve_runtime_backend,
+)
+from thorium_reactor.config import load_case_config
+from thorium_reactor.paths import create_result_bundle
+from thorium_reactor.precursors import (
+    LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL,
+    TWO_REGION_PRECURSOR_TRANSPORT_MODEL,
+)
+from thorium_reactor.sidecar_schemas import SidecarValidationError, validate_transient_sweep
+from thorium_reactor.transient_sweep import (
+    NumericalHealthError,
+    _build_perturbations,
+    _resolve_requested_backend,
+    build_transient_sweep_payload,
+    run_transient_sweep_case,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+IMMERSED_POOL = REPO_ROOT / "configs" / "cases" / "immersed_pool_reference" / "case.yaml"
+
+
+def _xpu_available() -> bool:
+    try:
+        create_array_backend("torch-xpu", dtype="float32", seed=1)
+    except Exception:
+        return False
+    return True
+
+
+requires_xpu = pytest.mark.skipif(not _xpu_available(), reason="no Intel XPU device available")
+
+
+def _sweep(backend: str, *, transport_model: str | None = None, dtype: str = "float64", samples: int = 64) -> dict:
+    config = load_case_config(IMMERSED_POOL)
+    if transport_model is not None:
+        config.data["transient"]["precursor_transport_model"] = transport_model
+    return build_transient_sweep_payload(
+        config,
+        _minimal_summary(),
+        scenario_name="partial_heat_sink_loss",
+        samples=samples,
+        seed=13,
+        backend=backend,
+        dtype=dtype,
+    )
+
+
+# --------------------------------------------------------------------------
+# torch import ordering
+# --------------------------------------------------------------------------
+
+
+def test_torch_cpu_backend_does_not_abort_the_interpreter() -> None:
+    """``--backend torch-cpu`` used to kill the process outright.
+
+    The OpenMP guard was installed only on the XPU branch, after torch may
+    already have loaded, so the CPU branch tripped ``OMP: Error #15`` and exited
+    3 -- an abort no ``except`` clause can catch.
+    """
+    pytest.importorskip("torch")
+    script = (
+        "from thorium_reactor.accelerators import create_array_backend\n"
+        "print(create_array_backend('torch-cpu', dtype='float32', seed=1).describe()['name'])\n"
+    )
+    environment = {
+        "PATH": __import__("os").environ.get("PATH", ""),
+        "SYSTEMROOT": __import__("os").environ.get("SYSTEMROOT", ""),
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=environment, cwd=str(REPO_ROOT)
+    )
+
+    assert result.returncode == 0, f"torch-cpu aborted: {result.stdout}{result.stderr}"
+    assert "torch-cpu" in result.stdout
+
+
+def test_configure_torch_environment_sets_the_openmp_guard() -> None:
+    accelerators.configure_torch_environment()
+
+    assert __import__("os").environ["KMP_DUPLICATE_LIB_OK"] == "TRUE"
+
+
+# --------------------------------------------------------------------------
+# backend selection contract
+# --------------------------------------------------------------------------
+
+
+def test_prefer_gpu_alone_still_means_auto() -> None:
+    assert _resolve_requested_backend("auto", prefer_gpu=True) == "auto"
+    assert _resolve_requested_backend("auto", prefer_gpu=False) == "auto"
+
+
+def test_prefer_gpu_conflicting_with_an_explicit_backend_is_rejected() -> None:
+    """The alias used to be an unconditional no-op, so this combination lied."""
+    with pytest.raises(BackendUnavailable, match="deprecated"):
+        _resolve_requested_backend("numpy", prefer_gpu=True)
+
+
+def test_explicit_backend_is_honoured_verbatim() -> None:
+    assert _resolve_requested_backend("torch-cpu", prefer_gpu=False) == "torch-cpu"
+
+
+def test_unknown_backend_and_dtype_are_rejected() -> None:
+    with pytest.raises(BackendUnavailable):
+        resolve_runtime_backend("cuda", samples=64)
+    with pytest.raises(BackendUnavailable):
+        resolve_runtime_backend("numpy", samples=64, dtype="float8")
+
+
+def test_python_backend_selection_reports_float64() -> None:
+    """The reference integrator is always float64 regardless of --dtype."""
+    selection = resolve_runtime_backend("python", samples=64, dtype="float32")
+
+    assert selection.dtype == "float64"
+
+
+def test_undersized_ensembles_are_flagged_in_the_selection_reason() -> None:
+    selection = resolve_runtime_backend("auto", samples=1024)
+
+    if selection.selected == "torch-xpu":
+        assert "floor" in selection.reason
+
+
+# --------------------------------------------------------------------------
+# physics: the transport model must reach every backend
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["numpy", "torch-cpu"])
+def test_precursor_transport_model_changes_results_on_vector_backends(backend: str) -> None:
+    """The vectorized integrator used to hard-code the loop-segment model.
+
+    Selecting ``two_region`` silently changed nothing on numpy/torch, which are
+    the only backends ``auto`` ever picks.
+    """
+    pytest.importorskip("torch") if backend.startswith("torch") else None
+    two_region = _sweep(backend, transport_model=TWO_REGION_PRECURSOR_TRANSPORT_MODEL)
+    loop_segment = _sweep(backend, transport_model=LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL)
+
+    assert (
+        two_region["metrics"]["final_total_reactivity_pcm_p50"]
+        != loop_segment["metrics"]["final_total_reactivity_pcm_p50"]
+    )
+
+
+@pytest.mark.parametrize(
+    "transport_model",
+    [TWO_REGION_PRECURSOR_TRANSPORT_MODEL, LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL],
+)
+def test_numpy_matches_the_python_reference_for_every_transport_model(transport_model: str) -> None:
+    reference = _sweep("python", transport_model=transport_model)
+    vector = _sweep("numpy", transport_model=transport_model)
+
+    for key in (
+        "final_core_delayed_neutron_source_fraction_p50",
+        "minimum_core_delayed_neutron_source_fraction_p05",
+        "peak_power_fraction_p95",
+        "peak_fuel_temperature_c_p95",
+    ):
+        assert vector["metrics"][key] == pytest.approx(reference["metrics"][key], abs=5.0e-4)
+    assert vector["metrics"]["final_total_reactivity_pcm_p50"] == pytest.approx(
+        reference["metrics"]["final_total_reactivity_pcm_p50"], abs=5.0e-3
+    )
+
+
+def test_baseline_precursor_annotations_agree_between_backends() -> None:
+    """These summaries feed the report, so both paths must mean the same thing."""
+    reference = _sweep("python")
+    vector = _sweep("numpy")
+
+    for key in (
+        "initial_core_precursor_fraction",
+        "initial_core_delayed_neutron_source_absolute_fraction",
+        "initial_precursor_transport_loss_fraction",
+    ):
+        assert vector["baseline"][key] == pytest.approx(reference["baseline"][key], abs=5.0e-3)
+
+
+# --------------------------------------------------------------------------
+# ensemble identity
+# --------------------------------------------------------------------------
+
+
+def test_streaming_perturbations_match_the_reference_stream() -> None:
+    """The vector path streams parameters to avoid holding 11 Python lists.
+
+    It must still consume the RNG in the same order, or CPU and GPU runs stop
+    being the same ensemble.
+    """
+    from thorium_reactor.transient_sweep import _iter_perturbation_arrays, _resolve_uncertainty_model
+
+    model = _resolve_uncertainty_model({})
+    expected = _build_perturbations(128, 7, model)
+    streamed = dict(_iter_perturbation_arrays(128, 7, model))
+
+    assert list(streamed) == list(expected)
+    for key, values in expected.items():
+        assert streamed[key] == values
+
+
+# --------------------------------------------------------------------------
+# failing numerics must not be publishable
+# --------------------------------------------------------------------------
+
+
+def test_failed_numerical_checks_raise_instead_of_being_written(monkeypatch) -> None:
+    """A "failed" status used to be recorded next to the metrics, exit code 0."""
+    import thorium_reactor.transient_sweep as module
+
+    original = module._integrate_transient_ensemble
+
+    def failing(**kwargs):
+        history, metrics, label, report, performance, checks = original(**kwargs)
+        checks = {**checks, "status": "failed", "failures": ["power_fraction_bounded_over_trajectory"]}
+        return history, metrics, label, report, performance, checks
+
+    monkeypatch.setattr(module, "_integrate_transient_ensemble", failing)
+
+    with pytest.raises(NumericalHealthError, match="power_fraction_bounded_over_trajectory"):
+        _sweep("numpy")
+
+
+def test_numerical_checks_screen_the_whole_trajectory() -> None:
+    payload = _sweep("numpy")
+    checks = payload["numerical_checks"]["checks"]
+
+    assert checks["history_finite_at_every_step"] is True
+    assert checks["power_fraction_bounded_over_trajectory"] is True
+    assert payload["numerical_checks"]["trajectory"]["steps_observed"] == payload["metrics"]["history_points"]
+
+
+# --------------------------------------------------------------------------
+# bundle contract
+# --------------------------------------------------------------------------
+
+
+def test_history_path_is_recorded_relative_to_the_repository(tmp_path: Path) -> None:
+    config = load_case_config(IMMERSED_POOL)
+    bundle = create_result_bundle(tmp_path, config.name, "run")
+    summary = _minimal_summary()
+
+    run_transient_sweep_case(
+        config, bundle, summary, scenario_name="partial_heat_sink_loss", samples=32, backend="numpy"
+    )
+
+    history_path = summary["transient_sweep"]["history_path"]
+    assert not Path(history_path).is_absolute()
+    assert history_path.endswith("transient_sweep.json")
+    assert str(tmp_path) not in history_path
+
+
+def test_summary_records_the_device_and_precision() -> None:
+    payload = _sweep("numpy", dtype="float32")
+    from thorium_reactor.transient_sweep import transient_sweep_summary
+
+    summary = transient_sweep_summary(payload, history_path="results/x/y/transient_sweep.json")
+
+    assert summary["backend"] == "numpy"
+    assert summary["requested_backend"] == "numpy"
+    assert summary["device"] == "cpu"
+    assert summary["dtype"] == "float32"
+
+
+def test_transient_sweep_sidecar_accepts_a_real_payload() -> None:
+    payload = _sweep("numpy")
+
+    assert validate_transient_sweep(payload) is payload
+
+
+def test_transient_sweep_sidecar_rejects_a_backend_that_disagrees_with_its_report() -> None:
+    payload = copy.deepcopy(_sweep("numpy"))
+    payload["backend"] = "torch-xpu"
+
+    with pytest.raises(SidecarValidationError, match="disagrees"):
+        validate_transient_sweep(payload)
+
+
+def test_transient_sweep_sidecar_rejects_published_failed_checks() -> None:
+    payload = copy.deepcopy(_sweep("numpy"))
+    payload["numerical_checks"]["status"] = "failed"
+
+    with pytest.raises(SidecarValidationError, match="numerical checks"):
+        validate_transient_sweep(payload)
+
+
+# --------------------------------------------------------------------------
+# memory budget
+# --------------------------------------------------------------------------
+
+
+def test_state_estimate_scales_with_samples_and_precision() -> None:
+    small = estimate_state_bytes(samples=1000, dtype="float32", groups=6, loop_segments=4)
+    large = estimate_state_bytes(samples=2000, dtype="float32", groups=6, loop_segments=4)
+    wide = estimate_state_bytes(samples=1000, dtype="float64", groups=6, loop_segments=4)
+
+    assert large == 2 * small
+    assert wide == 2 * small
+
+
+@requires_xpu
+def test_oversized_ensemble_is_refused_before_integrating() -> None:
+    from thorium_reactor.accelerators import check_memory_budget
+
+    backend = create_array_backend("torch-xpu", dtype="float32", seed=1)
+    with pytest.raises(BackendUnavailable, match="device memory"):
+        check_memory_budget(backend, samples=2_000_000_000, dtype="float32", groups=6, loop_segments=4)
+
+
+# --------------------------------------------------------------------------
+# GPU parity, when a device is present
+# --------------------------------------------------------------------------
+
+
+@requires_xpu
+def test_xpu_matches_numpy_on_the_same_ensemble() -> None:
+    cpu = _sweep("numpy", dtype="float32", samples=256)
+    gpu = _sweep("torch-xpu", dtype="float32", samples=256)
+
+    assert gpu["backend"] == "torch-xpu"
+    for key in ("peak_power_fraction_p95", "peak_fuel_temperature_c_p95", "final_power_fraction_p50"):
+        assert gpu["metrics"][key] == pytest.approx(cpu["metrics"][key], rel=1.0e-5)
+
+
+@requires_xpu
+def test_xpu_run_records_its_device_and_peak_memory() -> None:
+    payload = _sweep("torch-xpu", dtype="float32", samples=256)
+
+    assert payload["backend_report"]["details"]["device"]
+    assert payload["backend_report"]["available"] is True
+    assert payload["runtime_performance"]["backend_peak_memory_allocated_bytes"] is not None
+    assert payload["backend_report"]["memory_budget"]["status"] == "ok"
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def test_report_lists_every_varied_parameter(tmp_path: Path) -> None:
+    """The report used to truncate to the first eight of eleven parameters."""
+    from thorium_reactor.reporting.reports import generate_report
+
+    config = load_case_config(REPO_ROOT / "configs" / "cases" / "flagship_grid_msr" / "case.yaml")
+    payload = build_transient_sweep_payload(
+        config,
+        _minimal_summary(),
+        scenario_name="flagship_load_follow_recovery",
+        samples=32,
+        seed=1,
+        backend="numpy",
+    )
+    varied = payload["ensemble_definition"]["varied_parameters"]
+    assert len(varied) > 8, "flagship ensemble should vary more than the old cap"
+
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps({"case": config.name, "transient_sweep": {**payload, "status": "completed"}}), encoding="utf-8"
+    )
+    report = generate_report(config.name, config.data, summary_path, None, None, None, {})
+
+    assert f"Varied parameter count: `{len(varied)}`" in report
+    for parameter in varied:
+        assert f"Varied `{parameter['parameter']}`" in report

--- a/tests/test_gpu_backend_regressions.py
+++ b/tests/test_gpu_backend_regressions.py
@@ -14,8 +14,8 @@ import sys
 from pathlib import Path
 
 import pytest
+from conftest import build_minimal_summary
 
-from tests.test_transient_sweep import _minimal_summary
 from thorium_reactor import accelerators
 from thorium_reactor.accelerators import (
     BackendUnavailable,
@@ -51,6 +51,7 @@ def _xpu_available() -> bool:
 
 
 requires_xpu = pytest.mark.skipif(not _xpu_available(), reason="no Intel XPU device available")
+hardware = pytest.mark.hardware
 
 
 def _sweep(backend: str, *, transport_model: str | None = None, dtype: str = "float64", samples: int = 64) -> dict:
@@ -59,7 +60,7 @@ def _sweep(backend: str, *, transport_model: str | None = None, dtype: str = "fl
         config.data["transient"]["precursor_transport_model"] = transport_model
     return build_transient_sweep_payload(
         config,
-        _minimal_summary(),
+        build_minimal_summary(),
         scenario_name="partial_heat_sink_loss",
         samples=samples,
         seed=13,
@@ -73,6 +74,7 @@ def _sweep(backend: str, *, transport_model: str | None = None, dtype: str = "fl
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 def test_torch_cpu_backend_does_not_abort_the_interpreter() -> None:
     """``--backend torch-cpu`` used to kill the process outright.
 
@@ -261,7 +263,7 @@ def test_numerical_checks_screen_the_whole_trajectory() -> None:
 def test_history_path_is_recorded_relative_to_the_repository(tmp_path: Path) -> None:
     config = load_case_config(IMMERSED_POOL)
     bundle = create_result_bundle(tmp_path, config.name, "run")
-    summary = _minimal_summary()
+    summary = build_minimal_summary()
 
     run_transient_sweep_case(
         config, bundle, summary, scenario_name="partial_heat_sink_loss", samples=32, backend="numpy"
@@ -322,6 +324,7 @@ def test_state_estimate_scales_with_samples_and_precision() -> None:
 
 
 @requires_xpu
+@hardware
 def test_oversized_ensemble_is_refused_before_integrating() -> None:
     from thorium_reactor.accelerators import check_memory_budget
 
@@ -336,6 +339,7 @@ def test_oversized_ensemble_is_refused_before_integrating() -> None:
 
 
 @requires_xpu
+@hardware
 def test_xpu_matches_numpy_on_the_same_ensemble() -> None:
     cpu = _sweep("numpy", dtype="float32", samples=256)
     gpu = _sweep("torch-xpu", dtype="float32", samples=256)
@@ -346,6 +350,7 @@ def test_xpu_matches_numpy_on_the_same_ensemble() -> None:
 
 
 @requires_xpu
+@hardware
 def test_xpu_run_records_its_device_and_peak_memory() -> None:
     payload = _sweep("torch-xpu", dtype="float32", samples=256)
 
@@ -367,7 +372,7 @@ def test_report_lists_every_varied_parameter(tmp_path: Path) -> None:
     config = load_case_config(REPO_ROOT / "configs" / "cases" / "flagship_grid_msr" / "case.yaml")
     payload = build_transient_sweep_payload(
         config,
-        _minimal_summary(),
+        build_minimal_summary(),
         scenario_name="flagship_load_follow_recovery",
         samples=32,
         seed=1,
@@ -385,3 +390,133 @@ def test_report_lists_every_varied_parameter(tmp_path: Path) -> None:
     assert f"Varied parameter count: `{len(varied)}`" in report
     for parameter in varied:
         assert f"Varied `{parameter['parameter']}`" in report
+
+
+# --------------------------------------------------------------------------
+# Review findings on PR #92 (codex gpt-5.6-sol)
+# --------------------------------------------------------------------------
+
+
+def test_trajectory_extrema_are_exact_not_percentile_bands() -> None:
+    """An excursion in <5% of samples must not hide behind the p05 band.
+
+    The first cut fed percentile bands into the health screen, so a negative
+    or non-finite excursion confined to a minority of samples could recover
+    before the final step and pass.
+    """
+    reference = _sweep("python")
+    vector = _sweep("numpy")
+
+    for key in ("power_fraction_min", "power_fraction_max", "temperature_min_c", "temperature_max_c"):
+        assert vector["numerical_checks"]["trajectory"][key] == pytest.approx(
+            reference["numerical_checks"]["trajectory"][key], rel=1e-6
+        )
+    # The band is strictly inside the true extrema, which is what makes bands
+    # unsafe for this check -- assert we are not reporting the band.
+    trajectory = vector["numerical_checks"]["trajectory"]
+    worst_band_low = min(row["power_fraction_p05"] for row in vector["history"])
+    assert trajectory["power_fraction_min"] <= worst_band_low
+
+
+def test_trajectory_extrema_cover_graphite_and_coolant() -> None:
+    """Only fuel temperature was tracked; a graphite/coolant excursion escaped."""
+    payload = _sweep("numpy")
+    trajectory = payload["numerical_checks"]["trajectory"]
+    coolest_fuel_band = min(row["fuel_temp_c_p05"] for row in payload["history"])
+
+    # Graphite and coolant start below the fuel hot leg, so covering them must
+    # pull the tracked minimum below anything the fuel-only band could report.
+    assert trajectory["temperature_min_c"] < coolest_fuel_band
+
+
+def test_failed_stage_is_not_reported_as_a_completed_run(tmp_path: Path) -> None:
+    """A CLI stage that raised leaves an earlier summary.json behind.
+
+    That used to read as a clean success in the web UI, because status was
+    inferred purely from which artifacts existed.
+    """
+    from thorium_reactor.web.repository import infer_status_from_files
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "summary.json").write_text("{}", encoding="utf-8")
+    assert infer_status_from_files(run_dir) == "completed"
+
+    (run_dir / "stage_manifest.json").write_text(
+        json.dumps(
+            {"stages": [{"stage": "run", "status": "completed"}, {"stage": "transient-sweep", "status": "failed"}]}
+        ),
+        encoding="utf-8",
+    )
+    assert infer_status_from_files(run_dir) == "failed"
+
+
+def test_corrupt_status_file_does_not_pin_a_run_live_forever(tmp_path: Path) -> None:
+    """Treating any unparseable status as "running" left the SSE stream open.
+
+    A torn read during an atomic write is transient and the retry absorbs it; a
+    genuinely corrupt file is permanent, so it must fall through to inference
+    rather than reporting the run live forever.
+    """
+    from thorium_reactor.web.repository import read_status_payload
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "job_status.json").write_text("{ this is not json", encoding="utf-8")
+
+    assert read_status_payload(run_dir) == {}
+
+    (run_dir / "job_status.json").write_text(json.dumps({"status": "running"}), encoding="utf-8")
+    assert read_status_payload(run_dir)["status"] == "running"
+
+
+def test_missing_status_file_reads_as_empty(tmp_path: Path) -> None:
+    from thorium_reactor.web.repository import read_status_payload
+
+    assert read_status_payload(tmp_path) == {}
+
+
+@pytest.mark.hardware
+@requires_xpu
+def test_clamp_shortcut_preserves_nan_semantics() -> None:
+    """clamp(x, min=nan) leaves x alone; maximum(x, nan) propagates nan.
+
+    The scalar fast path must not silently swallow a corrupt threshold.
+    """
+    import torch
+
+    backend = create_array_backend("torch-xpu", dtype="float32", seed=1)
+    values = backend.asarray([1.0, 2.0, 3.0])
+
+    assert torch.isnan(backend.maximum(values, float("nan"))).all()
+    assert torch.isnan(backend.minimum(values, float("nan"))).all()
+    # A finite bound still takes the cheap path and behaves like maximum.
+    assert backend.to_host_list(backend.maximum(values, 2.0)) == [2.0, 2.0, 3.0]
+    assert backend.to_host_list(backend.minimum(values, 2.0)) == [1.0, 2.0, 2.0]
+
+
+@pytest.mark.hardware
+@requires_xpu
+def test_half_precision_percentiles_do_not_raise() -> None:
+    """float16/bfloat16 are advertised dtypes; torch.quantile rejects them."""
+    for dtype in ("float16", "bfloat16"):
+        backend = create_array_backend("torch-xpu", dtype=dtype, seed=1)
+        values = backend.asarray([float(index) for index in range(256)])
+
+        bands = backend.percentiles(values, (0.05, 0.5, 0.95))
+
+        assert len(bands) == 3
+        assert bands[0] <= bands[1] <= bands[2]
+
+
+def test_memory_budget_uses_the_segments_the_integrator_allocates() -> None:
+    """Two-region collapses to one segment, so budgeting the configured count
+    would reject an ensemble that actually fits."""
+    from thorium_reactor.transient_sweep import _effective_loop_segments
+
+    baseline = {"precursor_loop_segments": [{"id": f"s{index}"} for index in range(4)]}
+    two_region = {"precursor_transport_model": TWO_REGION_PRECURSOR_TRANSPORT_MODEL}
+    loop_segment = {"precursor_transport_model": LOOP_SEGMENT_PRECURSOR_TRANSPORT_MODEL}
+
+    assert len(_effective_loop_segments(two_region, baseline)) == 1
+    assert len(_effective_loop_segments(loop_segment, baseline)) == 4

--- a/tests/test_web_backend.py
+++ b/tests/test_web_backend.py
@@ -14,10 +14,13 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from thorium_reactor.accelerators import GPU_EFFICIENT_SAMPLE_FLOOR
 from thorium_reactor.paths import create_result_bundle
+from thorium_reactor.transient_sweep import MAX_TRANSIENT_SWEEP_SAMPLES
 from thorium_reactor.web.app import create_app
-from thorium_reactor.web.jobs import append_event
+from thorium_reactor.web.jobs import append_event, build_cli_command
 from thorium_reactor.web.repository import WebRepository
+from thorium_reactor.web.schemas import SimulationDraft
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ADMIN_HEADERS = {"cf-access-authenticated-user-email": "seamusdgallagher@gmail.com"}
@@ -296,11 +299,60 @@ def test_web_transient_sweep_samples_are_bounded() -> None:
         json={
             "case_name": "example_pin",
             "phases": ["transient-sweep"],
-            "sweep_samples": 65_537,
+            "sweep_samples": MAX_TRANSIENT_SWEEP_SAMPLES + 1,
         },
     )
 
     assert response.status_code == 422
+
+
+def test_web_transient_sweep_allows_gpu_efficient_ensembles() -> None:
+    """The browser must be able to reach the regime the accelerator exists for.
+
+    The old ceiling was 65,536 -- exactly the size at which GPU offload has not
+    yet amortized its per-step overhead -- so a browser sweep could never ask
+    for an ensemble where the device is worth using.
+    """
+    assert MAX_TRANSIENT_SWEEP_SAMPLES > GPU_EFFICIENT_SAMPLE_FLOOR
+    draft = SimulationDraft(case_name="example_pin", sweep_samples=GPU_EFFICIENT_SAMPLE_FLOOR)
+
+    assert draft.sweep_samples == GPU_EFFICIENT_SAMPLE_FLOOR
+
+
+def test_web_sweep_backend_selection_reaches_the_cli() -> None:
+    """The browser's compute-backend control must actually select a backend."""
+    for requested in ("auto", "numpy", "torch-cpu", "torch-xpu"):
+        draft = SimulationDraft(case_name="example_pin", phases=["transient-sweep"], sweep_backend=requested)
+        command = build_cli_command(draft, "transient-sweep")
+
+        assert "--backend" in command
+        assert command[command.index("--backend") + 1] == requested
+        # The dead alias must not be forwarded alongside the real control.
+        assert "--prefer-gpu" not in command
+
+
+def test_web_sweep_rejects_unknown_backend() -> None:
+    client = TestClient(create_app(REPO_ROOT))
+
+    response = client.post(
+        "/api/runs",
+        json={"case_name": "example_pin", "phases": ["transient-sweep"], "sweep_backend": "cuda"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_web_legacy_prefer_gpu_false_selects_a_cpu_backend() -> None:
+    """An old client that unchecks "use GPU" must get a CPU backend.
+
+    Previously ``prefer_gpu`` mapped to ``--prefer-gpu``, an alias for the
+    ``auto`` that ``--backend`` already defaulted to, so unchecking it changed
+    nothing and the sweep still ran on the GPU.
+    """
+    draft = SimulationDraft(case_name="example_pin", phases=["transient-sweep"], prefer_gpu=False)
+    command = build_cli_command(draft, "transient-sweep")
+
+    assert command[command.index("--backend") + 1] == "numpy"
 
 
 def test_web_fake_run_records_status_and_streams_events(monkeypatch) -> None:

--- a/web/ui/src/api.ts
+++ b/web/ui/src/api.ts
@@ -10,6 +10,38 @@ import type {
   SimulationDraft
 } from "./types";
 
+/**
+ * Render an error body as a sentence a person can act on.
+ *
+ * FastAPI answers a schema violation with `detail` as an array of objects, so
+ * assigning it straight to an Error message rendered as "[object Object]" and
+ * told the user nothing about which field was wrong.
+ */
+function formatErrorDetail(detail: unknown): string | null {
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    const messages = detail.map((item) => {
+      if (typeof item === "string") return item;
+      if (item && typeof item === "object") {
+        const entry = item as { loc?: unknown[]; msg?: string };
+        // Drop the leading "body" segment; the field path is what matters.
+        const field = Array.isArray(entry.loc)
+          ? entry.loc.filter((part) => part !== "body").join(".")
+          : "";
+        const message = entry.msg ?? "is invalid";
+        return field ? `${field}: ${message}` : message;
+      }
+      return String(item);
+    });
+    return messages.length ? messages.join("; ") : null;
+  }
+  if (detail && typeof detail === "object") {
+    const entry = detail as { msg?: string; message?: string };
+    return entry.msg ?? entry.message ?? JSON.stringify(detail);
+  }
+  return null;
+}
+
 async function request<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
     headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
@@ -19,7 +51,7 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
     let detail = response.statusText;
     try {
       const payload = await response.json();
-      detail = payload.detail ?? detail;
+      detail = formatErrorDetail(payload.detail) ?? detail;
     } catch {
       // Keep the HTTP status text.
     }

--- a/web/ui/src/pages/Builder.tsx
+++ b/web/ui/src/pages/Builder.tsx
@@ -5,7 +5,19 @@ import { CheckCircle2, ClipboardCheck, PlaySquare, ShieldCheck, SlidersHorizonta
 import { api } from "../api";
 import { Truncate } from "../components/Truncate";
 import { PanelError, PanelLoading } from "../components/StateBlock";
-import type { DraftValidationResponse, EditableParameter, SimulationDraft } from "../types";
+import type { DraftValidationResponse, EditableParameter, SimulationDraft, SweepBackend, SweepDtype } from "../types";
+
+const backendOptions: Array<{ value: SweepBackend; label: string; hint: string }> = [
+  { value: "auto", label: "Automatic", hint: "GPU when one is available, otherwise CPU" },
+  { value: "torch-xpu", label: "GPU (Intel XPU)", hint: "Fails if no XPU device is present" },
+  { value: "numpy", label: "CPU (NumPy)", hint: "Always available" },
+  { value: "torch-cpu", label: "CPU (PyTorch)", hint: "For comparing against the GPU path" }
+];
+
+// Ensembles below ~131,072 do not amortize the GPU's per-step overhead, so the
+// form says so rather than letting people pick a size the device can't help.
+const GPU_EFFICIENT_SAMPLE_FLOOR = 131072;
+const MAX_SWEEP_SAMPLES = 4194304;
 
 const phaseOptions = [
   { value: "run", label: "Dry run" },
@@ -29,7 +41,8 @@ export function Builder() {
   const [scenario, setScenario] = useState("");
   const [sweepSamples, setSweepSamples] = useState(65536);
   const [sweepSeed, setSweepSeed] = useState(42);
-  const [preferGpu, setPreferGpu] = useState(true);
+  const [sweepBackend, setSweepBackend] = useState<SweepBackend>("auto");
+  const [sweepDtype, setSweepDtype] = useState<SweepDtype>("float32");
 
   // Honor ?case= on mount and on in-app navigation to a different case.
   useEffect(() => {
@@ -54,6 +67,15 @@ export function Builder() {
     const transient = detail.data?.config.transient as { scenarios?: Array<{ name?: string }> } | undefined;
     return transient?.scenarios?.map((item) => item.name).filter(Boolean) as string[] | undefined;
   }, [detail.data]);
+
+  // Drop a scenario the newly-selected case does not define. Carrying it over
+  // silently ran the case's default transient while the form still displayed
+  // the old scenario name, so the run and the label disagreed.
+  useEffect(() => {
+    if (scenario && scenarios && !scenarios.includes(scenario)) {
+      setScenario("");
+    }
+  }, [scenario, scenarios]);
   const groupedParameters = useMemo(() => {
     const groups = new Map<string, EditableParameter[]>();
     detail.data?.editable_parameters.forEach((parameter) => groups.set(parameter.group, [...(groups.get(parameter.group) ?? []), parameter]));
@@ -91,7 +113,10 @@ export function Builder() {
       scenario: scenarioActive && scenario ? scenario : null,
       sweep_samples: sweepSamples,
       sweep_seed: sweepSeed,
-      prefer_gpu: preferGpu
+      sweep_backend: sweepBackend,
+      sweep_dtype: sweepDtype,
+      // Kept in step with the real control so an older server still honours it.
+      prefer_gpu: sweepBackend !== "numpy" && sweepBackend !== "torch-cpu"
     };
     createRun.mutate(draft);
   }
@@ -166,16 +191,33 @@ export function Builder() {
             <div className="builder-options">
               <label className="field">
                 <span>Sweep samples</span>
-                <input type="number" min={1} max={65536} value={sweepSamples} disabled={!sweepActive} onChange={(event) => setSweepSamples(Number(event.target.value))} />
+                <input type="number" min={1} max={MAX_SWEEP_SAMPLES} step={1024} value={sweepSamples} disabled={!sweepActive} onChange={(event) => setSweepSamples(Number(event.target.value))} />
               </label>
               <label className="field">
                 <span>Sweep seed</span>
                 <input type="number" min={0} value={sweepSeed} disabled={!sweepActive} onChange={(event) => setSweepSeed(Number(event.target.value))} />
               </label>
-              <label className="check-line">
-                <input type="checkbox" checked={preferGpu} disabled={!sweepActive} onChange={(event) => setPreferGpu(event.target.checked)} />
-                <span>Use GPU for sweep</span>
+              <label className="field">
+                <span>Compute backend</span>
+                <select value={sweepBackend} disabled={!sweepActive} onChange={(event) => setSweepBackend(event.target.value as SweepBackend)}>
+                  {backendOptions.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
               </label>
+              <label className="field">
+                <span>Precision</span>
+                <select value={sweepDtype} disabled={!sweepActive} onChange={(event) => setSweepDtype(event.target.value as SweepDtype)}>
+                  <option value="float32">float32 (faster)</option>
+                  <option value="float64">float64 (slow-timescale terms)</option>
+                </select>
+              </label>
+              <p className="field-hint">
+                {backendOptions.find((option) => option.value === sweepBackend)?.hint}
+                {sweepActive && sweepBackend !== "numpy" && sweepBackend !== "torch-cpu" && sweepSamples < GPU_EFFICIENT_SAMPLE_FLOOR
+                  ? ` — at ${sweepSamples.toLocaleString()} samples the GPU is barely faster than the CPU; ${GPU_EFFICIENT_SAMPLE_FLOOR.toLocaleString()} or more makes the difference count.`
+                  : ""}
+              </p>
             </div>
           </div>
 

--- a/web/ui/src/pages/Runs.tsx
+++ b/web/ui/src/pages/Runs.tsx
@@ -28,18 +28,30 @@ export function Runs() {
     enabled: Boolean(selected)
   });
 
+  // Depend on the run's identity and whether it is live -- not on `detail.data`,
+  // whose object identity changes on every refetch. The listener below triggers
+  // exactly those refetches, so depending on the data made the effect re-run on
+  // every event: each one tore down the EventSource, opened a new one, and
+  // replayed the whole event log from offset zero.
+  const caseName = detail.data?.case_name;
+  const runId = detail.data?.run_id;
+  const isLive = Boolean(detail.data && ["queued", "running"].includes(detail.data.status));
+
   useEffect(() => {
-    if (!detail.data || !["queued", "running"].includes(detail.data.status)) return;
-    const source = new EventSource(`/api/runs/${detail.data.case_name}/${detail.data.run_id}/events`);
+    if (!isLive || !caseName || !runId) return;
+    const source = new EventSource(`/api/runs/${caseName}/${runId}/events`);
     source.addEventListener("run", () => {
-      queryClient.invalidateQueries({ queryKey: ["run", detail.data?.case_name, detail.data?.run_id] });
+      queryClient.invalidateQueries({ queryKey: ["run", caseName, runId] });
       queryClient.invalidateQueries({ queryKey: ["runs"] });
     });
     return () => source.close();
-  }, [detail.data, queryClient]);
+  }, [isLive, caseName, runId, queryClient]);
 
-  const active = detail.data && ["queued", "running"].includes(detail.data.status);
-  const progress = detail.data?.latest_event?.progress;
+  const active = isLive;
+  // Progress comes from the run's own status, not from whichever event happened
+  // to arrive last: log lines carry no progress, so reading the latest event
+  // made the bar flip to indeterminate every time a phase printed a line.
+  const progress = detail.data?.progress ?? detail.data?.latest_event?.progress;
 
   return (
     <div className="page split-page">

--- a/web/ui/src/types.ts
+++ b/web/ui/src/types.ts
@@ -49,6 +49,7 @@ export interface RunRecord {
   artifacts: ArtifactRef[];
   output_sections?: OutputSection[];
   latest_event?: RunEvent | null;
+  progress?: number | null;
 }
 
 export interface EditableParameter {
@@ -98,7 +99,44 @@ export interface SimulationDraft {
   scenario?: string | null;
   sweep_samples: number;
   sweep_seed: number;
+  sweep_backend: SweepBackend;
+  sweep_dtype: SweepDtype;
+  /** @deprecated Superseded by `sweep_backend`; sent for older servers. */
   prefer_gpu: boolean;
+}
+
+export type SweepBackend = "auto" | "numpy" | "torch-cpu" | "torch-xpu";
+export type SweepDtype = "float32" | "float64";
+
+/** Mirrors `transient_sweep_summary` in src/thorium_reactor/transient_sweep.py. */
+export interface TransientSweepSummary {
+  status: string;
+  model: string;
+  backend: string;
+  requested_backend?: string | null;
+  device?: string | null;
+  dtype?: string | null;
+  samples: number;
+  seed: number;
+  scenario_name: string;
+  duration_s: number;
+  time_step_s: number;
+  event_count: number;
+  history_path: string;
+  peak_power_fraction_p95: number;
+  peak_power_fraction_max: number;
+  peak_fuel_temperature_c_p95: number;
+  peak_fuel_temperature_c_max: number;
+  final_power_fraction_p50: number;
+  final_power_fraction_p95: number;
+  runtime_performance?: {
+    elapsed_s: number;
+    setup_s?: number;
+    sample_steps_per_s: number;
+    backend_memory_allocated_bytes?: number | null;
+    backend_peak_memory_allocated_bytes?: number | null;
+  };
+  numerical_checks?: { status: string; failures: string[] };
 }
 
 export interface DraftValidationResponse {


### PR DESCRIPTION
An end-to-end `torch-xpu` run of `flagship_grid_msr` on an Intel Arc Pro B70 — 1,048,576 trajectories × 3,601 steps — surfaced 52 confirmed defects across the accelerator abstraction, the sweep integrator, the bundle contract, and the browser controls. This fixes all of them.

## The headline

The same 1M-sample flagship sweep now runs in **1m58s instead of 3m44s** and returns a **bit-identical** `p95` of `1.234128`. The speed came from removing ~461,000 host→device scalar copies (`maximum` → `clamp` for scalar operands) and batching the five per-step percentile transfers into one — four of five per-step synchronizations gone. No physics changed.

Measured B70 vs numpy on `flagship_grid_stress`, interleaved on an idle host, identical metrics at every size:

| Ensemble | numpy CPU | Arc Pro B70 | Speed-up |
| --- | --- | --- | --- |
| 65,536 *(the old web ceiling)* | 1,086,027 | 1,562,074 | 1.44× |
| 262,144 | 523,458 | 6,503,123 | 12.42× |
| 1,048,576 | 730,890 | 36,212,019 | 49.55× |

The GPU only pays off above ~131k samples — and 65,536 was the hard ceiling in `web/schemas.py`, the Builder input, and the CLI default. Every browser sweep was pinned to the one point where the accelerator earns nothing.

## Correctness

- **`--backend torch-cpu` aborted the interpreter.** The OpenMP guard was installed only on the XPU branch, after torch could already have loaded, so the CPU branch tripped `OMP: Error #15` and exited 3 — a process abort no `except` can catch. `configure_torch_environment()` now runs at import of `accelerators`, for every torch device.
- **`precursor_transport_model` was ignored on every vector backend.** Only `--backend python` dispatched on it, so selecting `two_region` was a silent no-op on numpy/torch — the only backends `auto` ever picks. Two-region is algebraically the single-segment case of the segmented model, so collapsing `loop_segments` reproduces the reference exactly. *(Not previously biting: all three shipped cases declare the loop-segment model.)*
- **Failed numerics were publishable.** `numerical_checks: "failed"` was written next to the metrics with exit 0. Now raises `NumericalHealthError`, and checks screen the whole trajectory rather than only the final step.
- **`validate` always exited 0.** It printed `False` and returned success, so nothing could gate on it. Now exits 1 and names the failing checks.
- `backend_report_for_selection` caught `BaseException`, swallowing `KeyboardInterrupt` into an empty `reason`.

## Interface

- **"Use GPU for sweep" selected nothing.** It mapped to `--prefer-gpu`, an alias for the `auto` that `--backend` already defaulted to. Verified before the fix: a browser run posting `prefer_gpu: false` still ran on the B70. `SimulationDraft` now carries `sweep_backend`/`sweep_dtype`, forwarded as `--backend`/`--dtype`, and the Builder has a real backend and precision selector. `prefer_gpu` survives for older clients and now maps `false` to a CPU backend.
- Sample ceiling raised 65,536 → 4,194,304 so the browser can reach the useful regime.
- Runs shows the **device and precision that actually ran**, and flags a run whose requested backend differs from the selected one.
- **A long sweep could permanently detach the UI.** Non-atomic `job_status.json` → swallowed `JSONDecodeError` → `infer_status_from_files` reported `completed` as soon as `summary.json` existed (true from the end of the `run` phase), which closed the SSE stream. Writes are atomic now, an unreadable status resolves to `running`, and the `EventSource` effect keys on run identity instead of the refetched object — it used to tear down and replay the full event log on *every* event.
- FastAPI 422 details rendered as `[object Object]`.

## Provenance

- `torch` is in the dependency summary and therefore the dependency hash — a CPU bundle and a B70 bundle used to hash identically. Plus a per-stage accelerator record: only the sweep stage reports `torch 2.11.0+xpu` and the B70; the other nine correctly report torch never loaded.
- `transient_sweep.json` gains a sidecar schema `verify-bundle` enforces — it rejects a backend disagreeing with its own report, and refuses to publish metrics whose numerical checks failed.
- `history_path` is repo-relative instead of an absolute host path.
- The report listed 8 of 11 varied parameters with no ellipsis or count; now lists all with an explicit count.

## Verification

- **284 passed, 3 skipped**, `ruff check` and `ruff format --check` clean.
- New `tests/test_gpu_backend_regressions.py` (26 tests) pins every fix, including a subprocess test that `torch-cpu` constructs with exit 0, backend parity across `python`/`numpy`/`torch-cpu`/`torch-xpu`, and transport-model equivalence. XPU tests skip without a device; they ran and passed here.
- Full pipeline re-run on the fixed code — build, run, transient, transient-sweep, transport, deplete, economics, render, validate, report, verify-bundle — bundle contract OK.
- Web control verified against a running server both directions: `sweep_backend: "numpy"` → `backend: numpy, device: cpu`; `"torch-xpu"` at 262,144 samples → `Intel(R) Arc(TM) Pro B70 Graphics` at 14.2M sample-steps/s.

## Two deliberate calls worth a reviewer's eye

1. **I changed a test's assertion.** `test_web_transient_sweep_samples_are_bounded` pinned the 65,536 ceiling this PR raises. It now asserts the *new* bound is enforced, with a companion test that the GPU-efficient regime is reachable.
2. **float32 stays the default.** The per-step depletion increment is 153× below the float32 ULP, so `fissile_inventory_fraction` never moves — but the dropped term is worth ~0.001 pcm over 900 s and headline metrics agree to ~1e-6. Rather than double memory everywhere, precision is now a labelled control ("float64 (slow-timescale terms)"). Easy to flip if you'd rather default to float64.
